### PR TITLE
Fixed up getscinfo for ceased sidechains

### DIFF
--- a/qa/pull-tester/rpc-tests.sh
+++ b/qa/pull-tester/rpc-tests.sh
@@ -92,6 +92,7 @@ testScripts=(
   'sc_cert_maturity.py'
   'sbh_rpc_cmds.py'
   'sc_cert_ceasing.py'
+  'sc_getscinfo.py'
 );
 testScriptsExt=(
   'getblocktemplate_longpoll.py'

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -219,9 +219,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         print("Verify all nodes see the new SC...")
-        scinfo0=self.nodes[0].getscinfo(scid)
-        scinfo1=self.nodes[1].getscinfo(scid)
-        scinfo2=self.nodes[2].getscinfo(scid)
+        scinfo0=self.nodes[0].getscinfo(scid)['items'][0]
+        scinfo1=self.nodes[1].getscinfo(scid)['items'][0]
+        scinfo2=self.nodes[2].getscinfo(scid)['items'][0]
         assert_equal(scinfo0,scinfo1)
         assert_equal(scinfo0,scinfo2)
         print(scinfo0)
@@ -257,9 +257,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
         print("Verify all nodes see the new FT...")
-        scinfo0=self.nodes[0].getscinfo(scid)
-        scinfo1=self.nodes[1].getscinfo(scid)
-        scinfo2=self.nodes[2].getscinfo(scid)
+        scinfo0=self.nodes[0].getscinfo(scid)['items'][0]
+        scinfo1=self.nodes[1].getscinfo(scid)['items'][0]
+        scinfo2=self.nodes[2].getscinfo(scid)['items'][0]
         assert_equal(scinfo0,scinfo1)
         assert_equal(scinfo0,scinfo2)
         print(scinfo0)

--- a/qa/rpc-tests/sbh_rpc_cmds.py
+++ b/qa/rpc-tests/sbh_rpc_cmds.py
@@ -20,7 +20,7 @@ EPOCH_LENGTH = 5
 CERT_FEE = Decimal('0.00015')
 
 def get_epoch_data( scid, node, epochLen):
-    sc_creating_height = node.getscinfo(scid)['created at block height']
+    sc_creating_height = node.getscinfo(scid)['items'][0]['created at block height']
     current_height = node.getblockcount()
     epoch_number = (current_height - sc_creating_height + 1) // epochLen - 1
     epoch_block_hash = node.getblockhash(sc_creating_height - 1 + ((epoch_number + 1) * epochLen))
@@ -74,32 +74,6 @@ class sbh_rpc_cmds(BitcoinTestFramework):
         # self.sync_all()
         time.sleep(2)
         self.is_network_split = False
-
-    def dump_sc_info_record(self, info, i):
-        if DEBUG_MODE == 0:
-            return
-        print "  Node %d - scid: %s" % (i, info["scid"])
-        print "    balance: %f" % (info["balance"])
-        print "    created in block: %s (%d)" % (info["created in block"], info["created at block height"])
-        print "    created in tx:    %s" % info["creating tx hash"]
-        print "    immature amounts:  ", info["immature amounts"]
-        print
-
-    def dump_sc_info(self, scId=""):
-        if scId != "":
-            print "-------------------------------------------------------------------------------------"
-            for i in range(0, NUMB_OF_NODES):
-                try:
-                    self.dump_sc_info_record(self.nodes[i].getscinfo(scId), i)
-                except JSONRPCException, e:
-                    print "  Node %d: ### [no such scid: %s]" % (i, scId)
-        else:
-            print "-------------------------------------------------------------------------------------"
-            for i in range(0, NUMB_OF_NODES):
-                x = self.nodes[i].getscinfo()
-                for info in x:
-                    self.dump_sc_info_record(info, i)
-        print
 
     def run_test(self):
 

--- a/qa/rpc-tests/sc_cert_base.py
+++ b/qa/rpc-tests/sc_cert_base.py
@@ -101,8 +101,8 @@ class sc_cert_base(BitcoinTestFramework):
         mark_logs("Node1 balance after SC creation: {}".format(bal_after_sc_creation), self.nodes, DEBUG_MODE)
         assert_equal(bal_before_sc_creation, bal_after_sc_creation + creation_amount - fee_sc_creation)
 
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to Sc
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -122,15 +122,15 @@ class sc_cert_base(BitcoinTestFramework):
         mark_logs("Node0 balance after fwd: {}".format(bal_after_fwd_tx), self.nodes, DEBUG_MODE)
         assert_equal(bal_before_fwd_tx, bal_after_fwd_tx + fwt_amount - fee_fwt - Decimal(8.75))  # 8.75 is matured coinbase
 
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
 
         mark_logs("Node0 generating 3 more blocks to achieve end of withdrawal epoch", self.nodes, DEBUG_MODE)
         self.nodes[0].generate(3)
         self.sync_all()
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         epoch_block_hash, epoch_number = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
         mark_logs("epoch_number = {}, epoch_block_hash = {}".format(epoch_number, epoch_block_hash), self.nodes, DEBUG_MODE)
@@ -156,8 +156,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("sidechain has insufficient funds" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount)
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         mark_logs("Node 0 tries to perform a bwd transfer with an invalid epoch number ...", self.nodes, DEBUG_MODE)
         amount_cert_1 = [{"pubkeyhash": pkh_node1, "amount": bwt_amount}]
@@ -170,8 +170,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("invalid epoch data" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         mark_logs("Node 0 tries to perform a bwd transfer with an invalid quality ...", self.nodes, DEBUG_MODE)
 
@@ -183,8 +183,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("Invalid quality parameter" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         # ----------------scProof tests-----------------
         mark_logs("Node 0 tries to perform a bwd transfer with a scProof too short ...", self.nodes, DEBUG_MODE)
@@ -197,8 +197,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("scProof: Invalid length" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
         
         #--------------------------------------------------------------------------------------
         
@@ -212,8 +212,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("scProof: Invalid length" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -227,8 +227,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("invalid cert scProof" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -247,8 +247,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
         
         #--------------------------------------------------------------------------------------
 
@@ -268,8 +268,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -288,8 +288,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -308,8 +308,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -328,8 +328,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -349,8 +349,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -371,8 +371,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("bad-sc-cert-not-applicable" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         #---------------------end scProof tests-------------------------
 
@@ -386,8 +386,8 @@ class sc_cert_base(BitcoinTestFramework):
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
         assert_equal("invalid epoch data" in errorString, True)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         epoch_number_0     = epoch_number
         epoch_block_hash_0 = epoch_block_hash
@@ -435,8 +435,8 @@ class sc_cert_base(BitcoinTestFramework):
         decoded_coinbase = self.nodes[2].getrawtransaction(coinbase, 1)
         miner_quota = decoded_coinbase['vout'][0]['value']
         assert_equal(miner_quota, (Decimal('7.5') + CERT_FEE))
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount- amount_cert_1[0]["amount"])
-        assert_equal(len(self.nodes[0].getscinfo(scid)['immature amounts']), 0)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount- amount_cert_1[0]["amount"])
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
 
         mark_logs("Node 0 tries to performs a bwd transfer for the same epoch number as before...", self.nodes, DEBUG_MODE)
         try:

--- a/qa/rpc-tests/sc_cert_ceasing.py
+++ b/qa/rpc-tests/sc_cert_ceasing.py
@@ -157,7 +157,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
         for k in range(len(scids)):
             for idx, node in enumerate(self.nodes):
                 print "idx = {}, k = {}".format(idx, k)
-                sc_info = node.getscinfo(scids[k])
+                sc_info = node.getscinfo(scids[k])['items'][0]
                 if (k == 2):
                     assert_equal(sc_info["state"], "CEASED")
                 else:
@@ -197,7 +197,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
         for k in range(len(scids)):
             for idx, node in enumerate(self.nodes):
                 print "idx = {}, k = {}".format(idx, k)
-                sc_info = node.getscinfo(scids[k])
+                sc_info = node.getscinfo(scids[k])['items'][0]
                 assert_equal(sc_info["state"], "CEASED")
                 assert_equal(sc_info["last certificate epoch"], last_cert_epochs[k])
                 assert_equal(sc_info["balance"], creation_amount[k] - bwt_amount[k])
@@ -210,7 +210,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
         for k in range(len(scids)):
             for idx, node in enumerate(self.nodes):
                 mark_logs("Checking Node{} after restart".format(idx), self.nodes, DEBUG_MODE)
-                sc_post_regeneration = node.getscinfo(scids[k])
+                sc_post_regeneration = node.getscinfo(scids[k])['items'][0]
                 assert_equal(sc_post_regeneration["state"], "CEASED")
                 assert_equal(sc_post_regeneration["last certificate epoch"], last_cert_epochs[k])
                 assert_equal(sc_post_regeneration["balance"], creation_amount[k] - bwt_amount[k])

--- a/qa/rpc-tests/sc_cert_epoch.py
+++ b/qa/rpc-tests/sc_cert_epoch.py
@@ -110,8 +110,8 @@ class sc_cert_epoch(BitcoinTestFramework):
         blocks.extend(self.nodes[0].generate(1))
         self.sync_all()
 
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], creation_amount + fwt_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['immature amounts'][0]['amount'], fwt_amount_immature_at_epoch)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], fwt_amount_immature_at_epoch)
 
         epoch_block_hash, epoch_number = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
         mark_logs("epoch_number = {}, epoch_block_hash = {}".format(epoch_number, epoch_block_hash), self.nodes, DEBUG_MODE)
@@ -175,7 +175,7 @@ class sc_cert_epoch(BitcoinTestFramework):
         assert_equal(node3_balance_ante_cert, self.nodes[3].getbalance())
 
         mark_logs("Checking Sc balance is duly decreased", self.nodes, DEBUG_MODE)
-        sc_post_bwd = self.nodes[0].getscinfo(scid)
+        sc_post_bwd = self.nodes[0].getscinfo(scid)['items'][0]
         assert_equal(sc_post_bwd["balance"], creation_amount + fwt_amount - bwt_amount)
 
         mark_logs("Checking that Node2 cannot immediately spend coins received from bwd transfer", self.nodes, DEBUG_MODE)
@@ -262,7 +262,7 @@ class sc_cert_epoch(BitcoinTestFramework):
         assert(speding_bwd_tx not in self.nodes[0].getrawmempool()) # speding_bwd_tx would spend an immature cert now since epoch 1 cert is not confirmed anymore
 
         mark_logs("Checking Sc balance is duly update due to bwd removal", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getscinfo(scid)["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
 
         mark_logs("Node0 invalidates latest block which signaled end of epoch 1", self.nodes, DEBUG_MODE)
         block_to_invalidate = self.nodes[0].getbestblockhash()
@@ -275,7 +275,7 @@ class sc_cert_epoch(BitcoinTestFramework):
 
         mark_logs("Node0 generating 4 block to show bwd has disappeared from history", self.nodes, DEBUG_MODE)
         blocks.extend(self.nodes[0].generate(4))
-        sc_post_regeneration = self.nodes[0].getscinfo(scid)
+        sc_post_regeneration = self.nodes[0].getscinfo(scid)['items'][0]
         assert_equal(sc_post_regeneration["last certificate epoch"], Decimal(0))
         assert_equal(sc_post_regeneration["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
 
@@ -287,7 +287,7 @@ class sc_cert_epoch(BitcoinTestFramework):
 
         for idx, node in enumerate(self.nodes):
             mark_logs("Checking Node{} ScInfos".format(idx), self.nodes, DEBUG_MODE)
-            sc_post_regeneration = node.getscinfo(scid)
+            sc_post_regeneration = node.getscinfo(scid)['items'][0]
             assert_equal(sc_post_regeneration["last certificate epoch"], Decimal(0))
             assert_equal(sc_post_regeneration["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
             assert(cert_epoch_1 not in node.getrawmempool())
@@ -303,7 +303,7 @@ class sc_cert_epoch(BitcoinTestFramework):
 
         for idx, node in enumerate(self.nodes):
             mark_logs("Checking Node{} after restart".format(idx), self.nodes, DEBUG_MODE)
-            sc_post_regeneration = node.getscinfo(scid)
+            sc_post_regeneration = node.getscinfo(scid)['items'][0]
             assert_equal(sc_post_regeneration["last certificate epoch"], Decimal(0))
             assert_equal(sc_post_regeneration["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
             assert(cert_epoch_1 not in node.getrawmempool())

--- a/qa/rpc-tests/sc_cert_fee.py
+++ b/qa/rpc-tests/sc_cert_fee.py
@@ -94,7 +94,7 @@ class sc_cert_base(BitcoinTestFramework):
         self.nodes[0].generate(4)
         self.sync_all()
 
-        mark_logs("Sc {} state: {}".format(scid, self.nodes[0].getscinfo(scid)), self.nodes, DEBUG_MODE)
+        mark_logs("Sc {} state: {}".format(scid, self.nodes[0].getscinfo(scid)['items'][0]), self.nodes, DEBUG_MODE)
 
         epoch_block_hash, epoch_number = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
         mark_logs("epoch_number = {}, epoch_block_hash = {}".format(epoch_number, epoch_block_hash), self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_cert_invalidate.py
+++ b/qa/rpc-tests/sc_cert_invalidate.py
@@ -55,7 +55,7 @@ class sc_cert_invalidate(BitcoinTestFramework):
         mark_logs("Node{} generating 1 block".format(nIdx), self.nodes, DEBUG_MODE)
         self.nodes[nIdx].generate(1)
         self.sync_all()
-        sc_info.append(self.nodes[nIdx].getscinfo(scid))
+        sc_info.append(self.nodes[nIdx].getscinfo(scid)['items'][0])
         mark_logs("  ==> height {}".format(self.nodes[nIdx].getblockcount()), self.nodes, DEBUG_MODE)
 
     def run_test(self):
@@ -237,7 +237,7 @@ class sc_cert_invalidate(BitcoinTestFramework):
                 break
 
             try:
-                assert_equal(self.nodes[0].getscinfo(scid), sc_info[-1])
+                assert_equal(self.nodes[0].getscinfo(scid)['items'][0], sc_info[-1])
             except JSONRPCException, e:
                 errorString = e.error['message']
                 print errorString
@@ -297,7 +297,7 @@ class sc_cert_invalidate(BitcoinTestFramework):
         assert_equal(self.nodes[0].getscinfo(scid), self.nodes[2].getscinfo(scid))
 
         mark_logs("check that sc balance is the amount we had in mempool at the end of invalidation phase", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getscinfo(scid)['balance'], sc_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], sc_amount)
 
         print "Node0 balance before: ", old_bal
         print "Node0 balance now   : ", self.nodes[0].getbalance()

--- a/qa/rpc-tests/sc_cert_orphans.py
+++ b/qa/rpc-tests/sc_cert_orphans.py
@@ -296,7 +296,7 @@ class sc_cert_orphans(BitcoinTestFramework):
 
         # verify network is aligned
         mark_logs("verifying that network is realigned", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[0].getscinfo(),        self.nodes[3].getscinfo())
+        assert_equal(self.nodes[0].getscinfo("*"),     self.nodes[3].getscinfo("*"))
         assert_equal(self.nodes[0].getrawmempool(),    self.nodes[3].getrawmempool())
         assert_equal(self.nodes[0].getblockcount(),    self.nodes[3].getblockcount())
         assert_equal(self.nodes[0].getbestblockhash(), self.nodes[3].getbestblockhash())

--- a/qa/rpc-tests/sc_cr_and_fw_in_mempool.py
+++ b/qa/rpc-tests/sc_cr_and_fw_in_mempool.py
@@ -201,7 +201,7 @@ class sc_cr_fw(BitcoinTestFramework):
 
         mark_logs("Check that sc balance is as expected", self.nodes, DEBUG_MODE)
         pprint.pprint(self.nodes[1].getscinfo(scid))
-        assert_equal(totScAmount, self.nodes[1].getscinfo(scid)['balance'])
+        assert_equal(totScAmount, self.nodes[1].getscinfo(scid)['items'][0]['balance'])
         mark_logs("Check that both nodes share the same view of sc info", self.nodes, DEBUG_MODE)
         assert_equal(self.nodes[0].getscinfo(scid), self.nodes[1].getscinfo(scid))
 

--- a/qa/rpc-tests/sc_create.py
+++ b/qa/rpc-tests/sc_create.py
@@ -298,9 +298,9 @@ class SCCreateTest(BitcoinTestFramework):
         self.sync_all()
 
         mark_logs("Verify all nodes see the new SC...", self.nodes, DEBUG_MODE)
-        scinfo0 = self.nodes[0].getscinfo(scid)
-        scinfo1 = self.nodes[1].getscinfo(scid)
-        scinfo2 = self.nodes[2].getscinfo(scid)
+        scinfo0 = self.nodes[0].getscinfo(scid)['items'][0]
+        scinfo1 = self.nodes[1].getscinfo(scid)['items'][0]
+        scinfo2 = self.nodes[2].getscinfo(scid)['items'][0]
         assert_equal(scinfo0, scinfo1)
         assert_equal(scinfo0, scinfo2)
 
@@ -317,9 +317,9 @@ class SCCreateTest(BitcoinTestFramework):
         curh = self.nodes[2].getblockcount()
         mark_logs("\nCheck maturiy of the coins", self.nodes, DEBUG_MODE)
 
-        dump_sc_info_record(self.nodes[2].getscinfo(scid), 2, DEBUG_MODE)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid)['items'][0], 2, DEBUG_MODE)
         mark_logs("Check that %f coins will be mature at h=%d" % (creation_amount, curh + 2), self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + SC_COINS_MAT:
                 assert_equal(entry["amount"], creation_amount)
@@ -347,11 +347,11 @@ class SCCreateTest(BitcoinTestFramework):
         # Check maturity of the coins at actual height
         curh = self.nodes[2].getblockcount()
 
-        dump_sc_info_record(self.nodes[2].getscinfo(scid), 2, DEBUG_MODE)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid)['items'][0], 2, DEBUG_MODE)
         count = 0
         mark_logs("Check that %f coins will be mature at h=%d" % (creation_amount, curh + 1), self.nodes, DEBUG_MODE)
         mark_logs("Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 2), self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
         for entry in ia:
             count += 1
             if entry["maturityHeight"] == curh + SC_COINS_MAT:
@@ -368,10 +368,10 @@ class SCCreateTest(BitcoinTestFramework):
         self.sync_all()
         curh = self.nodes[2].getblockcount()
 
-        dump_sc_info_record(self.nodes[2].getscinfo(scid), 2, DEBUG_MODE)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid)['items'][0], 2, DEBUG_MODE)
         count = 0
         mark_logs("Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 1), self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + SC_COINS_MAT - 1:
                 assert_equal(entry["amount"], fwt_amount_many + fwt_amount_1)
@@ -385,9 +385,9 @@ class SCCreateTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        dump_sc_info_record(self.nodes[2].getscinfo(scid), 2, DEBUG_MODE)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid)['items'][0], 2, DEBUG_MODE)
         mark_logs("Check that there are no immature coins", self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
         assert_equal(len(ia), 0)
 
 

--- a/qa/rpc-tests/sc_create_2.py
+++ b/qa/rpc-tests/sc_create_2.py
@@ -469,7 +469,7 @@ class SCCreateTest(BitcoinTestFramework):
         self.sync_all()
 
         dump_sc_info(self.nodes, NUMB_OF_NODES, sc_id, DEBUG_MODE)
-        assert_equal(self.nodes[0].getscinfo(sc_id)['scid'], sc_id)
+        assert_equal(self.nodes[0].getscinfo(sc_id)['items'][0]['scid'], sc_id)
 
         amount2 = 5.0
         mark_logs(("\nNode 0 sends %s to Node 1" % amount2), self.nodes, DEBUG_MODE)
@@ -532,7 +532,7 @@ class SCCreateTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        scinfo0 = self.nodes[0].getscinfo(scid)
+        scinfo0 = self.nodes[0].getscinfo(scid)['items'][0]
         mark_logs("...verify that scid and custom data are set as expected...", self.nodes, DEBUG_MODE)
         assert_equal(scinfo0['scid'], scid)
         assert_equal(scinfo0['wCertVk'], wCertVk)
@@ -567,7 +567,7 @@ class SCCreateTest(BitcoinTestFramework):
         self.nodes[0].generate(2)
         self.sync_all()
 
-        scinfo0 = self.nodes[0].getscinfo(scid)
+        scinfo0 = self.nodes[0].getscinfo(scid)['items'][0]
         if DEBUG_MODE:
             pprint.pprint(scinfo0)
 

--- a/qa/rpc-tests/sc_fwd_maturity.py
+++ b/qa/rpc-tests/sc_fwd_maturity.py
@@ -7,7 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import assert_equal, initialize_chain_clean, \
     mark_logs, start_nodes, sync_blocks, sync_mempools, connect_nodes_bi, \
-    disconnect_nodes
+    disconnect_nodes, dump_sc_info, dump_sc_info_record
 from test_framework.mc_test.mc_test import *
 import os
 from decimal import Decimal
@@ -17,7 +17,7 @@ NUMB_OF_NODES = 3
 DEBUG_MODE = 1
 
 
-class headers(BitcoinTestFramework):
+class sc_fwd_maturity(BitcoinTestFramework):
 
     alert_filename = None
 
@@ -63,31 +63,6 @@ class headers(BitcoinTestFramework):
         time.sleep(2)
         self.is_network_split = False
 
-    def dump_sc_info_record(self, info, i):
-        if DEBUG_MODE == 0:
-            return
-        print "  Node %d - scid: %s" % (i, info["scid"])
-        print "    balance: %f" % (info["balance"])
-        print "    created in block: %s (%d)" % (info["created in block"], info["created at block height"])
-        print "    created in tx:    %s" % info["creating tx hash"]
-        print "    immature amounts:  ", info["immature amounts"]
-        print
-
-    def dump_sc_info(self, scId=""):
-        if scId != "":
-            print "-------------------------------------------------------------------------------------"
-            for i in range(0, NUMB_OF_NODES):
-                try:
-                    self.dump_sc_info_record(self.nodes[i].getscinfo(scId), i)
-                except JSONRPCException, e:
-                    print "  Node %d: ### [no such scid: %s]" % (i, scId)
-        else:
-            print "-------------------------------------------------------------------------------------"
-            for i in range(0, NUMB_OF_NODES):
-                x = self.nodes[i].getscinfo()
-                for info in x:
-                    self.dump_sc_info_record(info, i)
-        print
 
     def run_test(self):
 
@@ -132,9 +107,9 @@ class headers(BitcoinTestFramework):
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 2:
                 assert_equal(entry["amount"], creation_amount)
@@ -180,12 +155,12 @@ class headers(BitcoinTestFramework):
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_2), 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_2)['items'][0], 2)
         count = 0
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 1)
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         for entry in ia:
             count += 1
             if entry["maturityHeight"] == curh + 2:
@@ -208,14 +183,14 @@ class headers(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        self.dump_sc_info()
+        dump_sc_info(self.nodes, NUMB_OF_NODES)
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 1)
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 1:
                 assert_equal(entry["amount"], fwt_amount_many + fwt_amount_1)
@@ -232,10 +207,10 @@ class headers(BitcoinTestFramework):
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that there are no immature coins"
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         assert_equal(len(ia), 0)
         print "...OK"
         print
@@ -251,10 +226,10 @@ class headers(BitcoinTestFramework):
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 1)
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 1:
                 assert_equal(entry["amount"], fwt_amount_many + fwt_amount_1)
@@ -275,11 +250,11 @@ class headers(BitcoinTestFramework):
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
+        dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 1)
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         for entry in ia:
             count += 1
             if entry["maturityHeight"] == curh + 2:
@@ -302,10 +277,9 @@ class headers(BitcoinTestFramework):
         # ----------------------------------------------------------------------------
         curh = self.nodes[2].getblockcount()
         print "Current height: ", curh
-        self.dump_sc_info()
-        self.dump_sc_info_record(self.nodes[2].getscinfo(scid_1), 2)
+        dump_sc_info(self.nodes, NUMB_OF_NODES)
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 2:
                 assert_equal(entry["amount"], creation_amount)
@@ -322,7 +296,7 @@ class headers(BitcoinTestFramework):
         print "Current height: ", self.nodes[2].getblockcount()
         print "Checking that sc info on Node2 is not available..."
         try:
-            print self.nodes[2].getscinfo(scid_1)
+            print self.nodes[2].getscinfo(scid_1)['items'][0]
         except JSONRPCException, e:
             errorString = e.error['message']
             print errorString
@@ -334,4 +308,4 @@ class headers(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    headers().main()
+    sc_fwd_maturity().main()

--- a/qa/rpc-tests/sc_getscinfo.py
+++ b/qa/rpc-tests/sc_getscinfo.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014 The Bitcoin Core developers
+# Copyright (c) 2018 The Zencash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, initialize_chain_clean, \
+    start_nodes, stop_nodes, get_epoch_data, \
+    sync_blocks, sync_mempools, connect_nodes_bi, wait_bitcoinds, mark_logs, \
+    assert_false, assert_true
+from test_framework.mc_test.mc_test import *
+import os
+import pprint
+import time
+from decimal import Decimal
+from random import randrange
+import math 
+
+DEBUG_MODE = 1
+NUMB_OF_NODES = 2
+
+
+class sc_getscinfo(BitcoinTestFramework):
+
+    alert_filename = None
+
+    def setup_chain(self, split=False):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, NUMB_OF_NODES)
+        self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
+        with open(self.alert_filename, 'w'):
+            pass  # Just open then close to create zero-length file
+
+    def setup_network(self, split=False):
+        self.nodes = []
+
+        self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir, extra_args=
+            [['-debug=py', '-debug=sc', '-debug=mempool', '-debug=net', '-debug=cert', '-logtimemicros=1']] * NUMB_OF_NODES)
+
+        for k in range(0, NUMB_OF_NODES-1):
+            connect_nodes_bi(self.nodes, k, k+1)
+
+        sync_blocks(self.nodes[1:NUMB_OF_NODES])
+        sync_mempools(self.nodes[1:NUMB_OF_NODES])
+        self.is_network_split = split
+        self.sync_all()
+
+    def run_test(self):
+
+        ''' 
+        (1) Create many SCs with increasing epoch length
+        (2) Advance chain so to have a mix of ceased and alive sidechains
+        (3) test getscinfo with filtering and pagination 
+        '''
+
+        creation_amount = Decimal("1.0")
+
+        mark_logs("Node 0 generates 110 block", self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(110)
+        self.sync_all()
+        mark_logs("Node 1 generates 110 block", self.nodes, DEBUG_MODE)
+        self.nodes[1].generate(110)
+        self.sync_all()
+        prev_epoch_hash = self.nodes[0].getbestblockhash()
+
+        #generate wCertVk and constant
+        mcTest = MCTestUtils(self.options.tmpdir, self.options.srcdir)
+
+        constant = generate_random_field_element_hex()
+
+        # number of sidechains to create
+        NUM_OF_SIDECHAINS = 10 + randrange(10)
+
+        # constant to obtain a number of alive sidechains for testing
+        SUBSET_ALIVE = 3 + randrange(3)
+
+        # base epoch length
+        EPOCH_LENGTH = 5 + randrange(5)
+
+        # number of blocks to generate for having a mixed set of ceased/alive sidechains
+        NUM_GEN = EPOCH_LENGTH + NUM_OF_SIDECHAINS - SUBSET_ALIVE
+
+        scids_all = []
+        scids_alive = []
+
+        # SCs creation
+        mark_logs("Creating {} sidechains".format(NUM_OF_SIDECHAINS), self.nodes, DEBUG_MODE)
+        for i in range(0, NUM_OF_SIDECHAINS):
+            tag = "sc"+str(i+1)
+            vk = mcTest.generate_params(tag)
+            # use two nodes for creating sc
+            idx = i%2
+            ret = self.nodes[int(idx)].sc_create(EPOCH_LENGTH+i, "dada", creation_amount, vk, "abcdef", constant)
+            creating_tx = ret['txid']
+            scid = self.nodes[idx].getrawtransaction(creating_tx, 1)['vsc_ccout'][0]['scid']
+            mark_logs("Node {} created SC {}".format(idx, scid), self.nodes, DEBUG_MODE)
+
+        self.sync_all()
+        # add created scs to the mainchain
+        cr_block_hash = self.nodes[0].generate(1)[-1]
+        self.sync_all()
+        
+        mark_logs("Node0 generates {} more blocks to achieve end of some withdrawal epochs".format(NUM_GEN), self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(NUM_GEN)
+        self.sync_all()
+
+        #------------------------------------------------------------------------------------------
+        mark_logs("Get all sidechains info in verbose mode", self.nodes, DEBUG_MODE)
+        sc_info_all              = self.nodes[1].getscinfo("*")
+        sc_info_all_default      = self.nodes[1].getscinfo("*", False, True, 0)
+        sc_info_all_to_big       = self.nodes[1].getscinfo("*", False, True, 0, 1000)
+        sc_info_all_to_unlimited = self.nodes[1].getscinfo("*", False, True, 0, -1)
+
+        # check the syntaxes above yield the same result
+        assert_equal(sc_info_all, sc_info_all_default)
+        assert_equal(sc_info_all, sc_info_all_to_big)
+        assert_equal(sc_info_all, sc_info_all_to_unlimited)
+
+        assert_equal(sc_info_all['totalItems'], NUM_OF_SIDECHAINS)
+        assert_equal(sc_info_all['from'], 0)
+        assert_equal(sc_info_all['to'], NUM_OF_SIDECHAINS)
+
+        # check all of them have right block creation hash which is part of verbose output
+        # and fill the ordered scids lists
+        for item in sc_info_all['items']:
+            assert_equal(item['created in block'], cr_block_hash)
+            scids_all.append(item['scid'])
+            if item['state'] == "ALIVE":
+                scids_alive.append(item['scid'])
+
+        NUM_ALIVE = len(scids_alive)
+
+        # get a ceased scid
+        for scid in scids_all:
+            if scid not in scids_alive:
+                a_ceased_scid = scid
+                break
+
+        #pprint.pprint(sc_info_all)
+
+        #------------------------------------------------------------------------------------------
+        mark_logs("Get only first two sidechains in non verbose mode", self.nodes, DEBUG_MODE)
+        sc_info = self.nodes[1].getscinfo("*", False, False, 0, 2)
+        assert_equal(sc_info['totalItems'], NUM_OF_SIDECHAINS)
+        assert_equal(sc_info['from'], 0)
+        assert_equal(sc_info['to'], 2)
+
+        mark_logs("tot {}".format(sc_info['totalItems']), self.nodes, DEBUG_MODE)
+
+        count = 0
+        for item in sc_info['items']:
+            try:
+                assert_equal(item['created in block'], cr_block_hash)
+                assert_true(False)
+            except Exception, e:
+                # it is ok, we expected it
+                pass
+
+            assert_equal(scids_all[count], item['scid'])
+            count += 1
+
+        #pprint.pprint(sc_info)
+
+        #------------------------------------------------------------------------------------------
+        sz_subset = 3
+        from_par = 5
+        to_par = from_par + sz_subset
+        mark_logs("Get only a subset of {} sidechains in verbose mode".format(sz_subset), self.nodes, DEBUG_MODE)
+        sc_info = self.nodes[1].getscinfo("*", False, True, from_par, to_par)
+        assert_equal(len(sc_info['items']), sz_subset)
+        assert_equal(sc_info['totalItems'], NUM_OF_SIDECHAINS)
+        assert_equal(sc_info['from'], from_par)
+        assert_equal(sc_info['to'], to_par)
+
+        count = from_par
+        for item in sc_info['items']:
+            assert_equal(item['created in block'], cr_block_hash)
+            assert_equal(scids_all[count], item['scid'])
+            count += 1
+
+        #pprint.pprint(sc_info)
+
+        #------------------------------------------------------------------------------------------
+        mark_logs("Get all alive sidechains with non-verbose output", self.nodes, DEBUG_MODE)
+        sc_info_all_alive = self.nodes[1].getscinfo("*", True, False)
+        assert_equal(sc_info_all_alive['totalItems'], NUM_ALIVE)
+        count = 0
+        for item in sc_info_all_alive['items']:
+            assert_equal(item['state'], "ALIVE")
+            assert_equal(scids_alive[count], item['scid'])
+            count += 1
+
+        #------------------------------------------------------------------------------------------
+        mark_logs("Get last {} alive sidechains with verbose output".format(SUBSET_ALIVE), self.nodes, DEBUG_MODE)
+        from_par = NUM_ALIVE - SUBSET_ALIVE
+        sc_info_sub_alive = self.nodes[1].getscinfo("*", True, True, from_par, -1)
+        assert_equal(sc_info_sub_alive['totalItems'], NUM_ALIVE)
+        assert_equal(sc_info_sub_alive['from'], from_par)
+        assert_equal(sc_info_sub_alive['to'], NUM_ALIVE)
+
+        count = from_par
+        for item in sc_info_sub_alive['items']:
+            assert_equal(item['state'], "ALIVE")
+            assert_equal(scids_alive[count], item['scid'])
+            count += 1
+
+        # negative tests
+        mark_logs("Negative tests", self.nodes, DEBUG_MODE)
+        #------------------------------------------------------------------------------------------
+        try:
+            self.nodes[1].getscinfo("*", False, True, -2, 5)
+            assert_true(False)
+        except JSONRPCException, e:
+            print e.error['message']
+            pass
+
+        try:
+            self.nodes[1].getscinfo("*", False, True, 5, 5)
+            assert_true(False)
+        except JSONRPCException, e:
+            print e.error['message']
+            pass
+
+        try:
+            self.nodes[1].getscinfo("*", True, True, 6, 5)
+            assert_true(False)
+        except JSONRPCException, e:
+            print e.error['message']
+            pass
+
+        try:
+            self.nodes[1].getscinfo("*", True, True, 1, -5)
+            assert_true(False)
+        except JSONRPCException, e:
+            print e.error['message']
+            pass
+
+        try:
+            self.nodes[1].getscinfo("*", False, True, NUM_OF_SIDECHAINS+2, -1)
+            assert_true(False)
+        except JSONRPCException, e:
+            print e.error['message']
+            pass
+
+        try:
+            # this is ok because the interval is legal
+            self.nodes[1].getscinfo("*", False, True, NUM_ALIVE, 100)
+        except JSONRPCException, e:
+            print e.error['message']
+            assert_true(False)
+
+        try:
+            # this is not OK because the interval is outside of filtered alive sc set
+            self.nodes[1].getscinfo("*", True, True, NUM_ALIVE, 100)
+            assert_true(False)
+        except JSONRPCException, e:
+            print e.error['message']
+            pass
+
+        # get a ceased sc info filtering on active state
+        null_result = self.nodes[0].getscinfo(a_ceased_scid, True)
+        pprint.pprint(null_result)
+        assert_equal(null_result['totalItems'], 0)
+        assert_equal(len(null_result['items']), int(0))
+
+        return
+
+        '''
+        bal1 = self.nodes[1].getbalance()
+        print "Balance Node1 = {}\n".format(bal1)
+        #assert_equal(bal1, bwt_amount[0])
+
+        mark_logs("Node0 generates 2 more blocks to achieve certs maturity and scs ceasing", self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(2)
+        self.sync_all()
+
+        bal1 = self.nodes[1].getbalance()
+        print "Balance Node1 = {}\n".format(bal1)
+        #assert_equal(bal1, bwt_amount[0])
+
+        mark_logs("Node0 generates 3 block to restore Node1 balance ", self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(3)
+        self.sync_all()
+
+        bal1 = self.nodes[1].getbalance()
+        print "Balance Node1 = {}\n".format(bal1)
+        #------> TODO fix this in walletassert_equal(bal1, Decimal("0.0"))
+
+        mark_logs("Node 1 tries to send coins to node0...", self.nodes, DEBUG_MODE)
+        try:
+            tx = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
+        except JSONRPCException, e:
+            errorString = e.error['message']
+            mark_logs(errorString, self.nodes, DEBUG_MODE)
+
+
+        mark_logs("Verifying scs state for all nodes", self.nodes, DEBUG_MODE)
+        for k in range(len(scids)):
+            for idx, node in enumerate(self.nodes):
+                print "idx = {}, k = {}".format(idx, k)
+                sc_info = node.getscinfo(scids[k])['items'][0]
+                assert_equal(sc_info["state"], "CEASED")
+                assert_equal(sc_info["last certificate epoch"], last_cert_epochs[k])
+                assert_equal(sc_info["balance"], creation_amount[k] - bwt_amount[k])
+
+        mark_logs("Checking certificates persistance stopping and restarting nodes", self.nodes, DEBUG_MODE)
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+        self.setup_network(False)
+
+        for k in range(len(scids)):
+            for idx, node in enumerate(self.nodes):
+                mark_logs("Checking Node{} after restart".format(idx), self.nodes, DEBUG_MODE)
+                sc_post_regeneration = node.getscinfo(scids[k])['items'][0]
+                assert_equal(sc_post_regeneration["state"], "CEASED")
+                assert_equal(sc_post_regeneration["last certificate epoch"], last_cert_epochs[k])
+                assert_equal(sc_post_regeneration["balance"], creation_amount[k] - bwt_amount[k])
+
+        bal1 = self.nodes[1].getbalance()
+        print "Balance Node1 = {}\n".format(bal1)
+        #------> TODO fix this in walletassert_equal(bal1, Decimal("0.0"))
+
+        mark_logs("Node0 generates 3 block to restore Node1 balance ", self.nodes, DEBUG_MODE)
+        self.nodes[0].generate(3)
+        self.sync_all()
+
+        mark_logs("Node 1 tries to send coins to node0...", self.nodes, DEBUG_MODE)
+        try:
+            tx = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
+        except JSONRPCException, e:
+            errorString = e.error['message']
+            mark_logs(errorString, self.nodes, DEBUG_MODE)
+        '''
+
+
+
+if __name__ == '__main__':
+    sc_getscinfo().main()

--- a/qa/rpc-tests/sc_invalidate.py
+++ b/qa/rpc-tests/sc_invalidate.py
@@ -169,12 +169,12 @@ class ScInvalidateTest(BitcoinTestFramework):
         self.sync_all()
 
         mark_logs("\nChecking SC info on Node 2 that should not have any SC...", self.nodes, DEBUG_MODE)
-        scinfoNode0 = self.nodes[0].getscinfo(scid)
-        scinfoNode1 = self.nodes[1].getscinfo(scid)
+        scinfoNode0 = self.nodes[0].getscinfo(scid)['items'][0]
+        scinfoNode1 = self.nodes[1].getscinfo(scid)['items'][0]
         mark_logs("Node 0: " + str(scinfoNode0), self.nodes, DEBUG_MODE)
         mark_logs("Node 1: " + str(scinfoNode1), self.nodes, DEBUG_MODE)
         try:
-            self.nodes[2].getscinfo(scid)
+            self.nodes[2].getscinfo(scid)['items'][0]
         except JSONRPCException, e:
             errorString = e.error['message']
             mark_logs(errorString, self.nodes, DEBUG_MODE)
@@ -202,7 +202,7 @@ class ScInvalidateTest(BitcoinTestFramework):
         mark_logs("\nChecking SC info on network, none see the SC...", self.nodes, DEBUG_MODE)
         for i in range(0, NUMB_OF_NODES):
             try:
-                self.nodes[i].getscinfo(scid)
+                self.nodes[i].getscinfo(scid)['items'][0]
             except JSONRPCException, e:
                 errorString = e.error['message']
                 mark_logs(errorString, self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_rawcertificate.py
+++ b/qa/rpc-tests/sc_rawcertificate.py
@@ -117,7 +117,7 @@ class sc_rawcert(BitcoinTestFramework):
 
         # -------------------------- end epoch
 
-        sc_funds_pre = self.nodes[3].getscinfo(scid)['balance']
+        sc_funds_pre = self.nodes[3].getscinfo(scid)['items'][0]['balance']
 
         pkh_node2 = self.nodes[2].getnewaddress("", True)
 
@@ -195,7 +195,7 @@ class sc_rawcert(BitcoinTestFramework):
             errorString = e.error['message']
             print "\n======> ", errorString
 
-        sc_funds_post = self.nodes[3].getscinfo(scid)['balance']
+        sc_funds_post = self.nodes[3].getscinfo(scid)['items'][0]['balance']
         assert_equal(sc_funds_post, sc_funds_pre - bt_amount)
 
         decoded_cert_post = self.nodes[2].getrawcertificate(cert, 1)
@@ -214,7 +214,7 @@ class sc_rawcert(BitcoinTestFramework):
         assert_equal(decoded_cert_pre_list, decoded_cert_post_list)
 
         mark_logs("check that SC balance has been decreased by the cert amount", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[2].getscinfo(scid)['balance'], (sc_amount - bt_amount))
+        assert_equal(self.nodes[2].getscinfo(scid)['items'][0]['balance'], (sc_amount - bt_amount))
 
         node0_bal_before = self.nodes[0].getbalance()
 
@@ -551,7 +551,7 @@ class sc_rawcert(BitcoinTestFramework):
         assert_equal(len(ret['vout']), 0)
 
         mark_logs("Check the certificate is the last received for this scid", self.nodes, DEBUG_MODE)
-        ret = self.nodes[2].getscinfo(scid)
+        ret = self.nodes[2].getscinfo(scid)['items'][0]
         assert_equal(ret['last certificate hash'], cert)
 
 

--- a/qa/rpc-tests/sc_split.py
+++ b/qa/rpc-tests/sc_split.py
@@ -147,20 +147,20 @@ class ScSplitTest(BitcoinTestFramework):
 
         # Check the sc info
         mark_logs("\nChecking sc info on 'honest' portion of network...", self.nodes, DEBUG_MODE)
-        scinfoNode0 = self.nodes[0].getscinfo(scid)
-        scinfoNode1 = self.nodes[1].getscinfo(scid)
+        scinfoNode0 = self.nodes[0].getscinfo(scid)['items'][0]
+        scinfoNode1 = self.nodes[1].getscinfo(scid)['items'][0]
         assert_equal(scinfoNode0, scinfoNode1)
         mark_logs("Node 0: " + str(scinfoNode0), self.nodes, DEBUG_MODE)
         mark_logs("Node 1: " + str(scinfoNode1), self.nodes, DEBUG_MODE)
         try:
-            mark_logs("Node 2: ", self.nodes[2].getscinfo(scid), self.nodes, DEBUG_MODE)
+            mark_logs("Node 2: ", self.nodes[2].getscinfo(scid)['items'][0], self.nodes, DEBUG_MODE)
         except JSONRPCException, e:
             errorString = e.error['message']
             mark_logs(errorString, self.nodes, DEBUG_MODE)
 
-        assert_equal(self.nodes[1].getscinfo(scid)["balance"], creation_amount + fwt_amount_1 + fwt_amount_2)
-        assert_equal(self.nodes[1].getscinfo(scid)["created in block"], ownerBlock)
-        assert_equal(self.nodes[1].getscinfo(scid)["creating tx hash"], creating_tx)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["balance"], creation_amount + fwt_amount_1 + fwt_amount_2)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["created in block"], ownerBlock)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["creating tx hash"], creating_tx)
         assert_equal("scid not yet created" in errorString, True)
 
         # ---------------------------------------------------------------------------------------
@@ -176,7 +176,7 @@ class ScSplitTest(BitcoinTestFramework):
 
         mark_logs("\nChecking that sc info on Node1 are not available anymore since tx has been reverted...", self.nodes, DEBUG_MODE)
         try:
-            mark_logs(self.nodes[1].getscinfo(scid), self.nodes, DEBUG_MODE)
+            mark_logs(self.nodes[1].getscinfo(scid)['items'][0], self.nodes, DEBUG_MODE)
         except JSONRPCException, e:
             errorString = e.error['message']
             mark_logs(errorString, self.nodes, DEBUG_MODE)
@@ -213,9 +213,9 @@ class ScSplitTest(BitcoinTestFramework):
             assert_equal(len(txmem), 0)
 
         mark_logs("\nChecking sc info on the whole network...", self.nodes, DEBUG_MODE)
-        scinfoNode0 = self.nodes[0].getscinfo(scid)
-        scinfoNode1 = self.nodes[1].getscinfo(scid)
-        scinfoNode2 = self.nodes[2].getscinfo(scid)
+        scinfoNode0 = self.nodes[0].getscinfo(scid)['items'][0]
+        scinfoNode1 = self.nodes[1].getscinfo(scid)['items'][0]
+        scinfoNode2 = self.nodes[2].getscinfo(scid)['items'][0]
 
         mark_logs("Node 0: " + str(scinfoNode0), self.nodes, DEBUG_MODE)
         mark_logs("Node 1: " + str(scinfoNode1), self.nodes, DEBUG_MODE)
@@ -223,9 +223,9 @@ class ScSplitTest(BitcoinTestFramework):
 
         assert_equal(scinfoNode0, scinfoNode1)
         assert_equal(scinfoNode0, scinfoNode2)
-        assert_equal(self.nodes[2].getscinfo(scid)["balance"], creation_amount + fwt_amount_1 + fwt_amount_2)
-        assert_equal(self.nodes[2].getscinfo(scid)["created in block"], secondOwnerBlock)
-        assert_equal(self.nodes[1].getscinfo(scid)["creating tx hash"], creating_tx)
+        assert_equal(self.nodes[2].getscinfo(scid)['items'][0]["balance"], creation_amount + fwt_amount_1 + fwt_amount_2)
+        assert_equal(self.nodes[2].getscinfo(scid)['items'][0]["created in block"], secondOwnerBlock)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["creating tx hash"], creating_tx)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -465,25 +465,25 @@ def dump_ordered_tips(tip_list,debug=0):
 def dump_sc_info_record(info, i, debug=0):
     if debug == 0:
         return
-    print ("  Node %d - balance: %f" % (i, info["balance"]))
-    print ("    created in block: %s (%d)" % (info["created in block"], info["created at block height"]))
-    print ("    created in tx:    %s" % info["creating tx hash"])
-    print ("    immature amounts:  ", info["immature amounts"])
+    print "  Node %d - balance: %f" % (i, info["balance"])
+    print "    created in block: %s (%d)" % (info["created in block"], info["created at block height"])
+    print "    created in tx:    %s" % info["creating tx hash"]
+    print "    immature amounts: %s" % info["immature amounts"]
 
 def dump_sc_info(nodes,nNodes,scId="",debug=0):
     if debug == 0:
         return
-    if scId != "":
+    if scId != "*":
         print ("scid: " + scId)
         print ("-------------------------------------------------------------------------------------")
         for i in range(0, nNodes):
             try:
-                dump_sc_info_record(nodes[i].getscinfo(scId), i,debug)
+                dump_sc_info_record(nodes[i].getscinfo(scId)['items'][0], i,debug)
             except JSONRPCException, e:
                 print "  Node %d: ### [no such scid: %s]" % (i, scId)
     else:
         for i in range(0, nNodes):
-            x = nodes[i].getscinfo()
+            x = nodes[i].getscinfo("*")['items']
             for info in x:
                 dump_sc_info_record(info, i,nNodes)
 
@@ -495,7 +495,7 @@ def mark_logs(msg,nodes,debug=0):
         node.dbg_log(msg)
 
 def get_epoch_data(scid, node, epochLen):
-    sc_creating_height = node.getscinfo(scid)['created at block height']
+    sc_creating_height = node.getscinfo(scid)['items'][0]['created at block height']
     current_height = node.getblockcount()
     epoch_number = (current_height - sc_creating_height + 1) // epochLen - 1
     epoch_block_hash = node.getblockhash(sc_creating_height - 1 + ((epoch_number + 1) * epochLen))

--- a/src/gtest/test_checkblock.cpp
+++ b/src/gtest/test_checkblock.cpp
@@ -146,7 +146,7 @@ TEST(CheckBlock, BlockRejectsNoCbh) {
 
     //std::cout << "Script: " << scriptPubKey.ToString() << std::endl;
 
-    mtx.addOut(CTxOut(0.5, scriptPubKey));
+    mtx.addOut(CTxOut(0.5 * COIN, scriptPubKey)); //CAmount is measured in zatoshi
 
     block.vtx.push_back(mtx);
 

--- a/src/gtest/test_checktransaction.cpp
+++ b/src/gtest/test_checktransaction.cpp
@@ -110,8 +110,8 @@ CMutableScCertificate GetValidCertificate() {
     CMutableScCertificate mcert;
 	mcert.nVersion = SC_CERT_VERSION;
 
-    mcert.addOut(CTxOut(0.5,CScript()));
-    mcert.addOut(CTxOut(1,CScript()));
+    mcert.addOut(CTxOut(0.5 * COIN,CScript())); //CAmount is measured in zatoshi
+    mcert.addOut(CTxOut(1 * COIN,CScript()));   //CAmount is measured in zatoshi
 
     mcert.scId = GetRandHash();
     mcert.epochNumber = 3;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1084,7 +1084,7 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
     return true;
 }
 
-bool FillScRecord(const uint256& scId, UniValue& scRecord, bool bOnlyAliv, bool bVerbosee)
+bool FillScRecord(const uint256& scId, UniValue& scRecord, bool bOnlyAlive, bool bVerbose)
 {
     CSidechain scInfo;
     CCoinsViewCache scView(pcoinsTip);
@@ -1094,7 +1094,7 @@ bool FillScRecord(const uint256& scId, UniValue& scRecord, bool bOnlyAliv, bool 
     }
     CSidechain::State scState = scView.isCeasedAtHeight(scId, chainActive.Height() + 1);
 
-    return FillScRecordFromInfo(scId, scInfo, scState, scRecord, bOnlyAliv, bVerbosee);
+    return FillScRecordFromInfo(scId, scInfo, scState, scRecord, bOnlyAlive, bVerbose);
 }
 
 int FillScList(UniValue& scItems, bool bOnlyAlive, bool bVerbose, int from=0, int to=-1)
@@ -1169,7 +1169,7 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
 			"3. verbose   (bool, optional, default=true) If false include only essential info in result\n"
             "   --- meaningful if scid is not specified:\n"
 			"4. from      (integer, optional, default=0) If set, limit the starting item index (0-base) in the result array to this entry (included)\n"
-			"5. to        (integer, optional, default=50) If set, limit the ending item index (0-base) in the result array to this entry (excluded) (-1 means max)\n"
+			"5. to        (integer, optional, default=-1) If set, limit the ending item index (0-base) in the result array to this entry (excluded) (-1 means max)\n"
             "\nReturns side chain info for the given id or for all of the existing sc if the id is not given.\n"
             "\nResult:\n"
             "{\n"
@@ -1261,7 +1261,7 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
         if (params.size() > 3)
     	    from = params[3].get_int();
 
-        int to = 50;
+        int to = -1;
         if (params.size() > 4)
     	    to = params[4].get_int();
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1032,7 +1032,7 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
-bool AddScInfoToJSON(const uint256& scId, const CSidechain& info, CSidechain::State scState, UniValue& sc, bool bOnlyAlive, bool bVerbose)
+bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechain::State scState, UniValue& sc, bool bOnlyAlive, bool bVerbose)
 {
     if (bOnlyAlive && (scState != CSidechain::State::ALIVE))
     	return false;
@@ -1084,69 +1084,78 @@ bool AddScInfoToJSON(const uint256& scId, const CSidechain& info, CSidechain::St
     return true;
 }
 
-bool AddScInfoToJSON(const uint256& scId, UniValue& sc, bool bOnlyAliv, bool bVerbosee)
+bool FillScRecord(const uint256& scId, UniValue& scRecord, bool bOnlyAliv, bool bVerbosee)
 {
     CSidechain scInfo;
     CCoinsViewCache scView(pcoinsTip);
     if (!scView.GetSidechain(scId, scInfo)) {
         LogPrint("sc", "scid[%s] not yet created\n", scId.ToString() );
-        return false;
+        throw JSONRPCError(RPC_INVALID_PARAMETER, string("scid not yet created: ") + scId.ToString());
     }
     CSidechain::State scState = scView.isCeasedAtHeight(scId, chainActive.Height() + 1);
 
-    return AddScInfoToJSON(scId, scInfo, scState, sc, bOnlyAliv, bVerbosee);
+    return FillScRecordFromInfo(scId, scInfo, scState, scRecord, bOnlyAliv, bVerbosee);
 }
 
-void AddScInfoToJSON(UniValue& result, bool bOnlyAlive, bool bVerbose, int from=0, int to=-1)
+int FillScList(UniValue& scItems, bool bOnlyAlive, bool bVerbose, int from=0, int to=-1)
 {
     CCoinsViewCache scView(pcoinsTip);
     std::set<uint256> sScIds;
     scView.GetScIds(sScIds);
 
-    std::cout << "Size of scids: " << sScIds.size() << std::endl;
+    if (sScIds.size() == 0)
+        return 0;
 
-
-    // check consistency of interval.
-    // --
-    // 'from' must be in the set interval
-    // 'to' must be either '-1', which means no upper bound interval, or 
-    // a formally valid upper bound interval number (positive and greater than 'from') but it is
-    // topped anyway to the upper bound value 
+    // means upper limit max
     if (to == -1)
     {
-        LogPrint("sc", "setting to[%d]->[%d]\n", to, sScIds.size());
-        to = sScIds.size();
-    }
-    else
-    if( to > sScIds.size())
-    {
-        LogPrint("sc", "setting to[%d]->[%d]\n", to, sScIds.size());
         to = sScIds.size();
     }
 
+    // basic check of interval parameters
     if ( from < 0 || to < 0 || from >= to)
     {
-        LogPrint("sc", "invalid from[%d], to[%d] (sz=%d)\n", from, to, sScIds.size());
+        LogPrint("sc", "invalid interval: from[%d], to[%d] (sz=%d)\n", from, to, sScIds.size());
         throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid interval");
     }
 
-    if (sScIds.size() == 0)
-        return;
-
+    UniValue totalResult(UniValue::VARR);
     std::set<uint256>::iterator it = sScIds.begin();
-    std::advance(it, from);
 
     while (it != sScIds.end())
     {
-        UniValue sc(UniValue::VOBJ);
-        if (AddScInfoToJSON(*it, sc, bOnlyAlive, bVerbose))
-            result.push_back(sc);
-
-        if (result.size() >= (to-from))
-            break;
-
+        UniValue scRecord(UniValue::VOBJ);
+        if (FillScRecord(*it, scRecord, bOnlyAlive, bVerbose))
+            totalResult.push_back(scRecord);
         ++it;
     }
+
+    // check consistency of interval in the filtered results list
+    // --
+    // 'from' must be in the valid interval
+    if (from >= totalResult.size())
+    {
+        LogPrint("sc", "invalid interval: from[%d] >= sz[%d]\n", from, totalResult.size());
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid interval");
+    }
+
+    // 'to' must be a formally valid upper bound interval number (positive and greater than 'from') but it is
+    // topped anyway to the upper bound value 
+    if (to > totalResult.size())
+    {
+        to = totalResult.size();
+    }
+
+    auto vec = totalResult.getValues();
+    auto first = vec.begin() + from;
+    auto last  = vec.begin() + to;
+
+    while (first != last)
+    {
+        scItems.push_back(*first++);
+    }
+
+    return vec.size(); 
 }
 
 UniValue getscinfo(const UniValue& params, bool fHelp)
@@ -1159,40 +1168,46 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
 			"2. onlyAlive (bool, optional, default=false) Retrieve only information for alive sidechains\n"
 			"3. verbose   (bool, optional, default=true) If false include only essential info in result\n"
             "   --- meaningful if scid is not specified:\n"
-			"4. from      (integer, optional, default=0) If set, limit the starting item index in the result array to this entry (included) (0 based)\n"
-			"5. to        (integer, optional, default=50) If set, limit the ending item index in the result array to this entry (excluded) (0 based)\n"
+			"4. from      (integer, optional, default=0) If set, limit the starting item index (0-base) in the result array to this entry (included)\n"
+			"5. to        (integer, optional, default=50) If set, limit the ending item index (0-base) in the result array to this entry (excluded) (-1 means max)\n"
             "\nReturns side chain info for the given id or for all of the existing sc if the id is not given.\n"
             "\nResult:\n"
-            "[\n"
-            "  {\n"
-            "    \"scid\":                    xxxxx,   (string)  sidechain ID\n"
-            "    \"balance\":                 xxxxx,   (numeric) available balance\n"
-            "    \"epoch\":                   xxxxx,   (numeric) current epoch for this sidechain\n"
-            "    \"end epoch height\":        xxxxx,   (numeric) height of the last block of the current epoch\n"
-            "    \"state\":                   xxxxx,   (string)  state of the sidechain at the current chain height\n"
-            "    \"ceasing height\":          xxxxx,   (numeric) height at which the sidechain is considered ceased if a certificate has not been received\n"
-            "    \"creating tx hash\":        xxxxx,   (string)  txid of the creating transaction\n"
-            "    \"created in block\":        xxxxx,   (string)  hash of the block containing the creatimg tx\n"
-            "    \"created at block height\": xxxxx,   (numeric) height of the above block\n"
-            "    \"last certificate epoch\":  xxxxx,   (numeric) last epoch number for which a certificate has been received\n"
-            "    \"last certificate hash\":   xxxxx,   (numeric) the hash of the last certificate that has been received\n"
-            "    \"withdrawalEpochLength\":   xxxxx,   (numeric) length of the withdrawal epoch\n"
-            "    \"wCertVk\":                 xxxxx,   (string)  The verification key needed to verify a Withdrawal Certificate Proof, set at sc creation\n"
-            "    \"customData\":              xxxxx,   (string)  The arbitrary byte string of custom data set at sc creation\n"
-            "    \"constant\":                xxxxx,   (string)  The arbitrary byte string of constant set at sc creation\n"
-            "    \"immature amounts\": [\n"
-            "      {\n"
-            "        \"maturityHeight\":      xxxxx,   (numeric) height at which fund will become part of spendable balance\n"
-            "        \"amount\":              xxxxx,   (numeric) immature fund\n"    
-            "      },\n"
-            "      ... ]\n"
-            "  },\n"
-            "  ...\n"
-            "]\n"
+            "{\n"
+            "  \"totalItems\":            xx,      (numeric) number of items found\n"
+            "  \"from\":                  xx,      (numeric) index of the starting item (included in result)\n" 
+            "  \"to\":                    xx,      (numeric) index of the ending item (excluded in result)\n"
+            "  \"items\":[\n"
+            "   {\n"
+            "     \"scid\":                    xxxxx,   (string)  sidechain ID\n"
+            "     \"balance\":                 xxxxx,   (numeric) available balance\n"
+            "     \"epoch\":                   xxxxx,   (numeric) current epoch for this sidechain\n"
+            "     \"end epoch height\":        xxxxx,   (numeric) height of the last block of the current epoch\n"
+            "     \"state\":                   xxxxx,   (string)  state of the sidechain at the current chain height\n"
+            "     \"ceasing height\":          xxxxx,   (numeric) height at which the sidechain is considered ceased if a certificate has not been received\n"
+            "     \"creating tx hash\":        xxxxx,   (string)  txid of the creating transaction\n"
+            "     \"created in block\":        xxxxx,   (string)  hash of the block containing the creatimg tx\n"
+            "     \"created at block height\": xxxxx,   (numeric) height of the above block\n"
+            "     \"last certificate epoch\":  xxxxx,   (numeric) last epoch number for which a certificate has been received\n"
+            "     \"last certificate hash\":   xxxxx,   (numeric) the hash of the last certificate that has been received\n"
+            "     \"withdrawalEpochLength\":   xxxxx,   (numeric) length of the withdrawal epoch\n"
+            "     \"wCertVk\":                 xxxxx,   (string)  The verification key needed to verify a Withdrawal Certificate Proof, set at sc creation\n"
+            "     \"customData\":              xxxxx,   (string)  The arbitrary byte string of custom data set at sc creation\n"
+            "     \"constant\":                xxxxx,   (string)  The arbitrary byte string of constant set at sc creation\n"
+            "     \"immature amounts\": [\n"
+            "       {\n"
+            "         \"maturityHeight\":      xxxxx,   (numeric) height at which fund will become part of spendable balance\n"
+            "         \"amount\":              xxxxx,   (numeric) immature fund\n"    
+            "       },\n"
+            "       ... ]\n"
+            "    },\n"
+            "    ...\n"
+            "  ]\n"
+            "}\n"
 
             "\nExamples\n"
             + HelpExampleCli("getscinfo", "\"1a3e7ccbfd40c4e2304c3215f76d204e4de63c578ad835510f580d529516a874\"")
-            + HelpExampleCli("getscinfo", "")
+            + HelpExampleCli("getscinfo", "\"*\" true false 2 10")
+            + HelpExampleCli("getscinfo", "\"*\" ")
         );
 
     bool bRetrieveAllSc = false;
@@ -1214,23 +1229,31 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
     	bVerbose = params[2].get_bool();
 
     UniValue ret(UniValue::VOBJ);
-    UniValue result(UniValue::VARR);
+    UniValue scItems(UniValue::VARR);
 
     if (!bRetrieveAllSc)
     {
+        // single search
         uint256 scId;
         scId.SetHex(inputString);
  
-        UniValue sc(UniValue::VOBJ);
-        if (!AddScInfoToJSON(scId, sc, bOnlyAlive, bVerbose) )
+        UniValue scRecord(UniValue::VOBJ);
+        // throws a json rpc exception if the scid is not found in the db
+        if (!FillScRecord(scId, scRecord, bOnlyAlive, bVerbose) )
         {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, string("scid not yet created: ") + scId.ToString());
+            // after filtering no sc has been found, this can happen for instance when the sc is ceased
+            // and bOnlyAlive is true
+            ret.push_back(Pair("totalItems", 0));
+            ret.push_back(Pair("from", 0));
+            ret.push_back(Pair("to", 0));
         }
-        result.push_back(sc);
-
-        ret.push_back(Pair("totalItems", 1));
-        ret.push_back(Pair("from", 0));
-        ret.push_back(Pair("to", 1));
+        else
+        {
+            ret.push_back(Pair("totalItems", 1));
+            ret.push_back(Pair("from", 0));
+            ret.push_back(Pair("to", 1));
+            scItems.push_back(scRecord);
+        }
     }
     else
     {
@@ -1242,14 +1265,16 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
         if (params.size() > 4)
     	    to = params[4].get_int();
 
-        AddScInfoToJSON(result, bOnlyAlive, bVerbose, from, to);
+        // throws a json rpc exception if the from/to parameters are invalid or out of the range of the
+        // retrieved scItems list
+        int tot = FillScList(scItems, bOnlyAlive, bVerbose, from, to);
 
-        ret.push_back(Pair("totalItems", result.size()));
+        ret.push_back(Pair("totalItems", tot));
         ret.push_back(Pair("from", from));
-        ret.push_back(Pair("to", from+result.size()));
+        ret.push_back(Pair("to", from + scItems.size()));
     }
 
-    ret.push_back(Pair("items", result));
+    ret.push_back(Pair("items", scItems));
     return ret;
 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1034,7 +1034,10 @@ UniValue reconsiderblock(const UniValue& params, bool fHelp)
 
 void AddScInfoToJSON(const uint256& scId, const CSidechain& info, CSidechain::State scState, UniValue& sc)
 {
-    int currentEpoch = info.EpochFor(chainActive.Height());
+    int currentEpoch = (scState == CSidechain::State::ALIVE)?
+            info.EpochFor(chainActive.Height()):
+            info.EpochFor(info.GetCeasingHeight());
+
     sc.push_back(Pair("scid", scId.GetHex()));
     sc.push_back(Pair("balance", ValueFromAmount(info.balance)));
     sc.push_back(Pair("epoch", currentEpoch));
@@ -1053,7 +1056,7 @@ void AddScInfoToJSON(const uint256& scId, const CSidechain& info, CSidechain::St
     sc.push_back(Pair("constant", HexStr(info.creationData.constant)));
 
     UniValue ia(UniValue::VARR);
-    BOOST_FOREACH(const auto& entry, info.mImmatureAmounts)
+    for(const auto& entry: info.mImmatureAmounts)
     {
         UniValue o(UniValue::VOBJ);
         o.push_back(Pair("maturityHeight", entry.first));

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -129,6 +129,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sc_create", 0 },
     { "sc_create", 2 },
     { "create_sidechain", 0 },
+	{ "getscinfo", 1 },
     { "send_to_sidechain", 0 },
     { "send_to_sidechain", 1 },
     { "send_certificate", 1 },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -130,6 +130,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sc_create", 2 },
     { "create_sidechain", 0 },
 	{ "getscinfo", 1 },
+	{ "getscinfo", 2 },
     { "send_to_sidechain", 0 },
     { "send_to_sidechain", 1 },
     { "send_certificate", 1 },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -131,6 +131,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "create_sidechain", 0 },
 	{ "getscinfo", 1 },
 	{ "getscinfo", 2 },
+	{ "getscinfo", 3 },
+	{ "getscinfo", 4 },
     { "send_to_sidechain", 0 },
     { "send_to_sidechain", 1 },
     { "send_certificate", 1 },

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -1122,14 +1122,14 @@ BOOST_AUTO_TEST_CASE(rpc_z_sendmany_internals)
         CTransaction tx = proxy.getTx();
         BOOST_CHECK(tx.GetVout().size() == 0);
 
-        CAmount amount = 123.456;
+        CAmount amount = 123.456 * COIN; //CAmount is measured in zatoshi
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
         BOOST_CHECK(tx.GetVout().size() == 1);
         CTxOut out = tx.GetVout()[0];
         BOOST_CHECK_EQUAL(out.nValue, amount);
 
-        amount = 1.111;
+        amount = 1.111 * COIN; //CAmount is measured in zatoshi
         proxy.add_taddr_change_output_to_tx(amount);
         tx = proxy.getTx();
         BOOST_CHECK(tx.GetVout().size() == 2);

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <sc/sidechaintypes.h>
+#include <zendoo/zendoo_mc.h>
 
 template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -795,7 +795,8 @@ UniValue sc_create(const UniValue& params, bool fHelp)
             "\nCreate a Side chain with the given id staring from the given block. A fixed amount is charged to the creator\n"
             "\nIt also sends cross chain forward transfer of coins multiple times. Amounts are double-precision floating point numbers."
             "\nArguments:\n"
-            "1. withdrawalEpochLength:   (numeric, required) Length of the withdrawal epochs\n"
+            "1. withdrawalEpochLength:   (numeric, required) Length of the withdrawal epochs. The minimum valid value for " +
+                                          Params().NetworkIDString() + " is: " +  strprintf("%d", Params().ScMinWithdrawalEpochLength()) + "\n"
             "2. \"address\"                (string, required) The receiver PublicKey25519Proposition in the SC\n"
             "3. amount:                  (numeric, required) The numeric amount in ZEN is the value\n"
             "4. \"wCertVk\"                (string, required) It is an arbitrary byte string of even length expressed in\n"
@@ -901,7 +902,9 @@ UniValue create_sidechain(const UniValue& params, bool fHelp)
             "\nCreate a Side chain.\n"
             "\nArguments:\n"
             "{\n"                     
-            "   \"withdrawalEpochLength\": epoch  (numeric, optional, default=100) length of the withdrawal epochs\n"
+            "   \"withdrawalEpochLength\": epoch  (numeric, optional, default=" + strprintf("%d", SC_RPC_OPERATION_DEFAULT_EPOCH_LENGTH) +
+                                                  ") length of the withdrawal epochs. The minimum valid value in " + Params().NetworkIDString() +
+                                                  " is: " +  strprintf("%d", Params().ScMinWithdrawalEpochLength()) + "\n"
             "   \"fromaddress\":taddr             (string, optional) The taddr to send the funds from. If omitted funds are taken from all available UTXO\n"
             "   \"changeaddress\":taddr           (string, optional) The taddr to send the change to, if any. If not set, \"fromaddress\" is used. If the latter is not set too, a new generated address will be used\n"
             "   \"toaddress\":scaddr              (string, required) The receiver PublicKey25519Proposition in the SC\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -852,7 +852,7 @@ UniValue sc_create(const UniValue& params, bool fHelp)
         }
     }
 
-    if ((params.size() > 4) && (!params[4].get_str().size() == 0))
+    if ((params.size() > 4) && (params[4].get_str().size() != 0))
     {
         const std::string& inputString = params[4].get_str();
         if(!Sidechain::AddScData(inputString, sc.creationData.customData, MAX_SC_DATA_LEN, false, error))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1000,7 +1000,7 @@ public:
      */
     CPubKey GenerateNewKey();
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey);
+    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)
@@ -1009,10 +1009,10 @@ public:
     bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
 
     //! Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret) override;
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
-    bool AddCScript(const CScript& redeemScript);
+    bool AddCScript(const CScript& redeemScript) override;
     bool LoadCScript(const CScript& redeemScript);
 
     //! Adds a destination data tuple to the store, and saves it to disk
@@ -1025,8 +1025,8 @@ public:
     bool GetDestData(const CTxDestination &dest, const std::string &key, std::string *value) const;
 
     //! Adds a watch-only address to the store, and saves it to disk.
-    bool AddWatchOnly(const CScript &dest);
-    bool RemoveWatchOnly(const CScript &dest);
+    bool AddWatchOnly(const CScript &dest) override;
+    bool RemoveWatchOnly(const CScript &dest) override;
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);
 
@@ -1050,11 +1050,11 @@ public:
     //! Adds an encrypted spending key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedZKey(const libzcash::PaymentAddress &addr, const libzcash::ReceivingKey &rk, const std::vector<unsigned char> &vchCryptedSecret);
     //! Adds an encrypted spending key to the store, and saves it to disk (virtual method, declared in crypter.h)
-    bool AddCryptedSpendingKey(const libzcash::PaymentAddress &address, const libzcash::ReceivingKey &rk, const std::vector<unsigned char> &vchCryptedSecret);
+    bool AddCryptedSpendingKey(const libzcash::PaymentAddress &address, const libzcash::ReceivingKey &rk, const std::vector<unsigned char> &vchCryptedSecret) override;
 
     //! Adds a viewing key to the store, and saves it to disk.
-    bool AddViewingKey(const libzcash::ViewingKey &vk);
-    bool RemoveViewingKey(const libzcash::ViewingKey &vk);
+    bool AddViewingKey(const libzcash::ViewingKey &vk) override;
+    bool RemoveViewingKey(const libzcash::ViewingKey &vk) override;
     //! Adds a viewing key to the store, without saving it to disk (used by LoadWallet)
     bool LoadViewingKey(const libzcash::ViewingKey &dest);
 


### PR DESCRIPTION
Fixed up scInfo for ceased sidechain, in order to keep epoch and end epoch height locked to ceasing epoch for ceased sidechains.
It would close issues https://github.com/HorizenOfficial/zend_oo/issues/38 https://github.com/HorizenOfficial/zend_oo/issues/42 and https://github.com/HorizenOfficial/zend_oo/issues/44