### PR TITLE
Speedup SelectCoins with remove/erase idioms

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3052,21 +3052,8 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTra
     // remove preset inputs from vCoins
     if((coinControl != nullptr)	&& coinControl->HasSelected())
     {
-        struct predicate
-        {
-            predicate(const std::set<std::pair<const CWalletTransactionBase*, uint32_t>>& setCoins):
-                _setCoins(setCoins) {};
-
-            bool operator()(const COutput& out)
-            {
-                return _setCoins.count(make_pair(out.tx, out.pos));
-            };
-
-        private:
-            const std::set<std::pair<const CWalletTransactionBase*, uint32_t>>& _setCoins;
-        } isInputPreset(setPresetCoins);
-
-        auto it = std::remove_if(vCoins.begin(), vCoins.end(), isInputPreset);
+    	auto isPresent = [&](const COutput& out) {return setPresetCoins.count(make_pair(out.tx, out.pos));};
+    	std::vector<COutput>::const_iterator it = std::remove_if(vCoins.begin(), vCoins.end(), isPresent);
         vCoins.erase(it, vCoins.end());
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3050,12 +3050,24 @@ bool CWallet::SelectCoins(const CAmount& nTargetValue, set<pair<const CWalletTra
     }
 
     // remove preset inputs from vCoins
-    for (vector<COutput>::iterator it = vCoins.begin(); it != vCoins.end() && coinControl && coinControl->HasSelected();)
+    if((coinControl != nullptr)	&& coinControl->HasSelected())
     {
-        if (setPresetCoins.count(make_pair(it->tx, it->pos)))
-            it = vCoins.erase(it);
-        else
-            ++it;
+        struct predicate
+        {
+            predicate(const std::set<std::pair<const CWalletTransactionBase*, uint32_t>>& setCoins):
+                _setCoins(setCoins) {};
+
+            bool operator()(const COutput& out)
+            {
+                return _setCoins.count(make_pair(out.tx, out.pos));
+            };
+
+        private:
+            const std::set<std::pair<const CWalletTransactionBase*, uint32_t>>& _setCoins;
+        } isInputPreset(setPresetCoins);
+
+        auto it = std::remove_if(vCoins.begin(), vCoins.end(), isInputPreset);
+        vCoins.erase(it, vCoins.end());
     }
 
     bool res = nTargetValue <= nValueFromPresetInputs ||


### PR DESCRIPTION
Scanning a vector and removing specific items one by one can cause relocation and results in a O(N^2) complexity.
[Erase/Remove idiom](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom)  guarantees linear complexity instead since all elements marked for removal are erased at once