### PR TITLE
Refactored mempool::remove to extract list of dependencies

### DIFF
--- a/qa/rpc-tests/sc_cert_ceasing.py
+++ b/qa/rpc-tests/sc_cert_ceasing.py
@@ -124,6 +124,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
                 quality, constant, [pkh_node1], [bwt_amount[0]])
 
             cert_1 = self.nodes[0].send_certificate(scids[0], epoch_number, quality, epoch_block_hash, proof, amounts, CERT_FEE)
+            self.sync_all()
             mark_logs("==> certificate is {}".format(cert_1), self.nodes, DEBUG_MODE)
         except JSONRPCException, e:
             errorString = e.error['message']
@@ -140,6 +141,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
                 quality, constant, [], [])
 
             cert_2 = self.nodes[0].send_certificate(scids[1], epoch_number, quality, epoch_block_hash, proof, [], CERT_FEE)
+            self.sync_all()
             mark_logs("==> certificate is {}".format(cert_2), self.nodes, DEBUG_MODE)
         except JSONRPCException, e:
             errorString = e.error['message']
@@ -147,7 +149,6 @@ class sc_cert_ceasing(BitcoinTestFramework):
             assert(False)
 
         # no certs for scid 3, let it cease without having one 
-        self.sync_all()
 
         mark_logs("Node0 generates 5 more blocks to achieve end of withdrawal epochs", self.nodes, DEBUG_MODE)
         self.nodes[0].generate(5)

--- a/src/gtest/test_sidechain_to_mempool.cpp
+++ b/src/gtest/test_sidechain_to_mempool.cpp
@@ -256,7 +256,7 @@ TEST_F(SidechainsInMempoolTestSuite, FwdsOnlyInMempool_FwdNonRecursiveRemoval) {
 
 TEST_F(SidechainsInMempoolTestSuite, ScAndFwdsInMempool_ScRecursiveRemoval) {
     // Associated scenario: Sidechain creation and some fwds are in mempool, e.g. as a result of previous blocks disconnections
-    // One of the new blocks about to me mounted double spends the original fwdTx, hence scCreation is marked for recursive removal by removeForConflicts
+    // One of the new blocks about to me mounted double spends the original scTx, hence scCreation is marked for recursive removal by removeForConflicts
     // both scCreation and fwds must be cleared from mempool
 
     CTxMemPool aMempool(::minRelayTxFee);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -179,6 +179,8 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256& hash, const CCertificateMemPoolEntry &entry, bool fCurrentEstimate = true);
 
+    std::set<uint256> mempoolDirectDependenciesOf(const CTransactionBase& root);
+    std::set<uint256> mempoolFullDependenciesOf(const CTransactionBase& origTx);
     void remove(const CTransactionBase& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive = false);
 
     void removeWithAnchor(const uint256 &invalidRoot);


### PR DESCRIPTION
As some corner case from multiple certificate handling, we need the list of dependencies for a given tx/cert in mempool.
I have extracted a function providing just this info from mempool::remove which, in its recursive case, eliminates from mempool a given tx/cert and the full list of its mempool dependencies.
I think the refactoring does improves also readability of mempool::remove which performs a depth-first-seach on the mempool direct acyclic graph of txes and cert dependencies.

Targeting our base branch for quality cert development