### PR TITLE
Minor refactoring of mempool algos

### DIFF
--- a/src/gtest/test_sidechain_to_mempool.cpp
+++ b/src/gtest/test_sidechain_to_mempool.cpp
@@ -640,11 +640,11 @@ TEST_F(SidechainsInMempoolTestSuite, ImmatureExpenditureRemoval) {
 
 TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsInEmptyMempool) {
     // prerequisites
-	CTxMemPool aMempool(::minRelayTxFee);
+    CTxMemPool aMempool(::minRelayTxFee);
 
-	CAmount dummyAmount(10);
-	CScript dummyScript;
-	CTxOut dummyOut(dummyAmount, dummyScript);
+    CAmount dummyAmount(10);
+    CScript dummyScript;
+    CTxOut dummyOut(dummyAmount, dummyScript);
 
     CMutableTransaction tx_1;
     tx_1.vin.push_back(CTxIn(uint256(), 0, dummyScript));
@@ -657,16 +657,16 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsInEmptyMempool) {
 
 TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfSingleTransaction) {
     // prerequisites
-	CTxMemPool aMempool(::minRelayTxFee);
+    CTxMemPool aMempool(::minRelayTxFee);
 
-	CAmount dummyAmount(10);
-	CScript dummyScript;
-	CTxOut dummyOut(dummyAmount, dummyScript);
+    CAmount dummyAmount(10);
+    CScript dummyScript;
+    CTxOut dummyOut(dummyAmount, dummyScript);
 
-	CMutableTransaction tx_1;
+    CMutableTransaction tx_1;
     tx_1.vin.push_back(CTxIn(uint256(), 0, dummyScript));
     tx_1.addOut(dummyOut);
-	CTxMemPoolEntry tx_1_entry(tx_1, /*fee*/dummyAmount, /*time*/ 1000, /*priority*/1.0, /*height*/1987);
+    CTxMemPoolEntry tx_1_entry(tx_1, /*fee*/dummyAmount, /*time*/ 1000, /*priority*/1.0, /*height*/1987);
 
     //test
     aMempool.addUnchecked(tx_1.GetHash(), tx_1_entry);
@@ -679,12 +679,12 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfSingleTransaction)
 
 TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfSimpleChain) {
     // prerequisites
-	CTxMemPool aMempool(::minRelayTxFee);
-	CAmount dummyAmount(10);
-	CScript dummyScript;
-	CTxOut dummyOut(dummyAmount, dummyScript);
+    CTxMemPool aMempool(::minRelayTxFee);
+    CAmount dummyAmount(10);
+    CScript dummyScript;
+    CTxOut dummyOut(dummyAmount, dummyScript);
 
-	// Create chain tx_1 -> tx_2 -> tx_3
+    // Create chain tx_1 -> tx_2 -> tx_3
     CMutableTransaction tx_1;
     tx_1.vin.push_back(CTxIn(uint256(), 0, dummyScript));
     tx_1.addOut(dummyOut);
@@ -704,20 +704,20 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfSimpleChain) {
 
     //checks
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_1).empty());
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_1) == std::set<uint256>({tx_2.GetHash(),tx_3.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_2) == std::set<uint256>({tx_1.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_2) == std::set<uint256>({tx_3.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_3) == std::set<uint256>({tx_1.GetHash(),tx_2.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_1) == std::vector<uint256>({tx_2.GetHash(),tx_3.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_2) == std::vector<uint256>({tx_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_2) == std::vector<uint256>({tx_3.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_3) == std::vector<uint256>({tx_2.GetHash(),tx_1.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_3).empty());
 }
 
 TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfTree) {
     // prerequisites
-	CTxMemPool aMempool(::minRelayTxFee);
-	CAmount dummyAmount(10);
-	CScript dummyScript;
-	CTxOut dummyOut_1(dummyAmount, dummyScript);
-	CTxOut dummyOut_2(++dummyAmount, dummyScript);
+    CTxMemPool aMempool(::minRelayTxFee);
+    CAmount dummyAmount(10);
+    CScript dummyScript;
+    CTxOut dummyOut_1(dummyAmount, dummyScript);
+    CTxOut dummyOut_2(++dummyAmount, dummyScript);
 
     CMutableTransaction tx_root;
     tx_root.vin.push_back(CTxIn(uint256(), 0, dummyScript));
@@ -758,30 +758,30 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfTree) {
     //checks
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_root).empty());
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root)
-        == std::set<uint256>({tx_child_1.GetHash(), tx_child_2.GetHash(),
-                              tx_grandchild_1.GetHash(), tx_grandchild_2.GetHash(), tx_grandchild_3.GetHash()}));
+        == std::vector<uint256>({tx_child_1.GetHash(), tx_child_2.GetHash(),
+                                       tx_grandchild_2.GetHash(), tx_grandchild_1.GetHash(), tx_grandchild_3.GetHash()}));
 
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_1) == std::set<uint256>({tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::set<uint256>({tx_grandchild_1.GetHash(), tx_grandchild_2.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_1) == std::vector<uint256>({tx_root.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::vector<uint256>({tx_grandchild_1.GetHash(), tx_grandchild_2.GetHash()}));
 
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_2) == std::set<uint256>({tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_2) == std::set<uint256>({tx_grandchild_3.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_2) == std::vector<uint256>({tx_root.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_2) == std::vector<uint256>({tx_grandchild_3.GetHash()}));
 
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::set<uint256>({tx_root.GetHash(),tx_child_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::vector<uint256>({tx_child_1.GetHash(), tx_root.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_1).empty());
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_2) == std::set<uint256>({tx_root.GetHash(),tx_child_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_2) == std::vector<uint256>({tx_child_1.GetHash(), tx_root.GetHash(),}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_2).empty());
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_3) == std::set<uint256>({tx_root.GetHash(),tx_child_2.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_3) == std::vector<uint256>({tx_child_2.GetHash(), tx_root.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_3).empty());
 }
 
 TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfTDAG) {
     // prerequisites
-	CTxMemPool aMempool(::minRelayTxFee);
-	CAmount dummyAmount(10);
-	CScript dummyScript;
-	CTxOut dummyOut_1(dummyAmount, dummyScript);
-	CTxOut dummyOut_2(++dummyAmount, dummyScript);
+    CTxMemPool aMempool(::minRelayTxFee);
+    CAmount dummyAmount(10);
+    CScript dummyScript;
+    CTxOut dummyOut_1(dummyAmount, dummyScript);
+    CTxOut dummyOut_2(++dummyAmount, dummyScript);
 
     CMutableTransaction tx_root;
     tx_root.vin.push_back(CTxIn(uint256(), 0, dummyScript));
@@ -804,14 +804,15 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfTDAG) {
 
     //checks
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_root).empty());
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root) == std::set<uint256>({tx_child_1.GetHash(), tx_grandchild_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root) == std::vector<uint256>({tx_child_1.GetHash(), tx_grandchild_1.GetHash()}));
 
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_1) == std::set<uint256>({tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::set<uint256>({tx_grandchild_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_1) == std::vector<uint256>({tx_root.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::vector<uint256>({tx_grandchild_1.GetHash()}));
 
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::set<uint256>({tx_root.GetHash(),tx_child_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::vector<uint256>({tx_root.GetHash(),tx_child_1.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_1).empty());
 }
+
 ///////////////////////////////////////////////////////////////////////////////
 ////////////////////////// Test Fixture definitions ///////////////////////////
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/gtest/test_sidechain_to_mempool.cpp
+++ b/src/gtest/test_sidechain_to_mempool.cpp
@@ -704,10 +704,11 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfSimpleChain) {
 
     //checks
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_1).empty());
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_1) == std::vector<uint256>({tx_2.GetHash(),tx_3.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_2) == std::vector<uint256>({tx_1.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_2) == std::vector<uint256>({tx_3.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_3) == std::vector<uint256>({tx_2.GetHash(),tx_1.GetHash()}));
+
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_1) == std::vector<uint256>({tx_2.GetHash(),tx_3.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_2) == std::vector<uint256>({tx_3.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_3).empty());
 }
 
@@ -757,21 +758,19 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfTree) {
 
     //checks
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_root).empty());
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root)
-        == std::vector<uint256>({tx_child_1.GetHash(), tx_child_2.GetHash(),
-                                       tx_grandchild_2.GetHash(), tx_grandchild_1.GetHash(), tx_grandchild_3.GetHash()}));
-
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_1) == std::vector<uint256>({tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::vector<uint256>({tx_grandchild_1.GetHash(), tx_grandchild_2.GetHash()}));
-
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_2) == std::vector<uint256>({tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_2) == std::vector<uint256>({tx_grandchild_3.GetHash()}));
-
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::vector<uint256>({tx_child_1.GetHash(), tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_1).empty());
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_2) == std::vector<uint256>({tx_child_1.GetHash(), tx_root.GetHash(),}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_2).empty());
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_2) == std::vector<uint256>({tx_child_1.GetHash(), tx_root.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_3) == std::vector<uint256>({tx_child_2.GetHash(), tx_root.GetHash()}));
+
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root)
+        == std::vector<uint256>({tx_child_1.GetHash(), tx_grandchild_2.GetHash(), tx_grandchild_1.GetHash(),
+                                 tx_child_2.GetHash(), tx_grandchild_3.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::vector<uint256>({tx_grandchild_1.GetHash(), tx_grandchild_2.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_2) == std::vector<uint256>({tx_grandchild_3.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_1).empty());
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_2).empty());
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_3).empty());
 }
 
@@ -804,12 +803,11 @@ TEST_F(SidechainsInMempoolTestSuite, AncestorsAndDescendantsOfTDAG) {
 
     //checks
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_root).empty());
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root) == std::vector<uint256>({tx_child_1.GetHash(), tx_grandchild_1.GetHash()}));
-
     EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_child_1) == std::vector<uint256>({tx_root.GetHash()}));
-    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::vector<uint256>({tx_grandchild_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::vector<uint256>({tx_child_1.GetHash(),tx_root.GetHash()}));
 
-    EXPECT_TRUE(aMempool.mempoolFullAncestorsOf(tx_grandchild_1) == std::vector<uint256>({tx_root.GetHash(),tx_child_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_root) == std::vector<uint256>({tx_child_1.GetHash(), tx_grandchild_1.GetHash()}));
+    EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_child_1) == std::vector<uint256>({tx_grandchild_1.GetHash()}));
     EXPECT_TRUE(aMempool.mempoolFullDescendantsOf(tx_grandchild_1).empty());
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1124,7 +1124,7 @@ bool AcceptCertificateToMemoryPool(CTxMemPool& pool, CValidationState &state, co
         }
 
         // No lower quality certs should spend (directly or indirectly) outputs of higher or equal quality certs
-        std::set<uint256> certAncestors = pool.mempoolFullAncestorsOf(cert);
+        std::vector<uint256> certAncestors = pool.mempoolFullAncestorsOf(cert);
         for(const uint256& ancestor: certAncestors)
         {
             if (pool.mapCertificate.count(ancestor)==0)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -234,9 +234,8 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CCertificateMemPoolEntr
 
 std::vector<uint256> CTxMemPool::mempoolDirectAncestorsOf(const CTransactionBase& root) const
 {
-    std::vector<uint256> res;
-
     AssertLockHeld(cs);
+    std::vector<uint256> res;
 
     //collect all inputs in mempool (zero-spent ones)...
     for(const auto& input : root.GetVin()) {
@@ -264,10 +263,12 @@ std::vector<uint256> CTxMemPool::mempoolDirectAncestorsOf(const CTransactionBase
 
 std::vector<uint256> CTxMemPool::mempoolFullAncestorsOf(const CTransactionBase& originTx) const
 {
-    AssertLockHeld(cs);
     // it's Breath-First-Search on txes/certs Direct Acyclic Graph, having originTx as root.
+
+    AssertLockHeld(cs);
     std::vector<uint256> res = mempoolDirectAncestorsOf(originTx);
-    std::deque<uint256> toVisit(res.begin(), res.end());
+    std::deque<uint256> toVisit{res.begin(), res.end()};
+    res.clear();
 
     while(!toVisit.empty())
     {
@@ -297,9 +298,8 @@ std::vector<uint256> CTxMemPool::mempoolFullAncestorsOf(const CTransactionBase& 
 
 std::vector<uint256> CTxMemPool::mempoolDirectDescendantsOf(const CTransactionBase& root) const
 {
-    std::vector<uint256> res;
-
     AssertLockHeld(cs);
+    std::vector<uint256> res;
 
     //Direct dependencies of root are txes/certs directly spending root outputs...
     for (unsigned int i = 0; i < root.GetVout().size(); i++)
@@ -338,9 +338,9 @@ std::vector<uint256> CTxMemPool::mempoolFullDescendantsOf(const CTransactionBase
     // it's Depth-First-Search on txes/certs Direct Acyclic Graph, having originTx as root.
 
     AssertLockHeld(cs);
-
     std::vector<uint256> res = mempoolDirectDescendantsOf(origTx);
-    std::deque<uint256> toVisit(res.begin(), res.end());
+    std::deque<uint256> toVisit{res.begin(), res.end()};
+    res.clear();
 
     while(!toVisit.empty())
     {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -232,16 +232,16 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CCertificateMemPoolEntr
     return true;
 }
 
-std::set<uint256> CTxMemPool::mempoolDirectAncestorsOf(const CTransactionBase& root) const
+std::vector<uint256> CTxMemPool::mempoolDirectAncestorsOf(const CTransactionBase& root) const
 {
-    std::set<uint256> res; //set allows to avoid duplicates
+    std::vector<uint256> res;
 
     AssertLockHeld(cs);
 
     //collect all inputs in mempool (zero-spent ones)...
     for(const auto& input : root.GetVin()) {
         if ((mapTx.count(input.prevout.hash) != 0) || (mapCertificate.count(input.prevout.hash) != 0))
-            res.insert(input.prevout.hash);
+            res.push_back(input.prevout.hash);
     }
 
     //... and scCreations of all possible fwt
@@ -255,18 +255,18 @@ std::set<uint256> CTxMemPool::mempoolDirectAncestorsOf(const CTransactionBase& r
 
         for(const auto& fwt: tx->GetVftCcOut()) {
             if (mapSidechains.count(fwt.scId) && !mapSidechains.at(fwt.scId).scCreationTxHash.IsNull())
-                res.insert(mapSidechains.at(fwt.scId).scCreationTxHash);
+                res.push_back(mapSidechains.at(fwt.scId).scCreationTxHash);
         }
     }
 
     return res;
 }
 
-std::set<uint256> CTxMemPool::mempoolFullAncestorsOf(const CTransactionBase& originTx) const
+std::vector<uint256> CTxMemPool::mempoolFullAncestorsOf(const CTransactionBase& originTx) const
 {
     AssertLockHeld(cs);
     // it's Breath-First-Search on txes/certs Direct Acyclic Graph, having originTx as root.
-    std::set<uint256> res = mempoolDirectAncestorsOf(originTx);
+    std::vector<uint256> res = mempoolDirectAncestorsOf(originTx);
     std::deque<uint256> toVisit(res.begin(), res.end());
 
     while(!toVisit.empty())
@@ -281,11 +281,13 @@ std::set<uint256> CTxMemPool::mempoolFullAncestorsOf(const CTransactionBase& ori
             assert(pCurrentNode);
 
         toVisit.pop_back();
-        res.insert(pCurrentNode->GetHash());
+        if (std::find(res.begin(), res.end(), pCurrentNode->GetHash()) == res.end())
+            res.push_back(pCurrentNode->GetHash());
 
-        std::set<uint256> directAncestors = mempoolDirectAncestorsOf(*pCurrentNode);
+        std::vector<uint256> directAncestors = mempoolDirectAncestorsOf(*pCurrentNode);
         for(const uint256& ancestor : directAncestors) {
-            if (std::find(toVisit.begin(), toVisit.end(), ancestor) == toVisit.end())
+            if ( (std::find(toVisit.begin(), toVisit.end(), ancestor) == toVisit.end()) &&
+                 (std::find(res.begin(), res.end(), ancestor) == res.end()))
                 toVisit.push_front(ancestor);
         }
     }
@@ -293,9 +295,9 @@ std::set<uint256> CTxMemPool::mempoolFullAncestorsOf(const CTransactionBase& ori
     return res;
 }
 
-std::set<uint256> CTxMemPool::mempoolDirectDescendantsOf(const CTransactionBase& root) const
+std::vector<uint256> CTxMemPool::mempoolDirectDescendantsOf(const CTransactionBase& root) const
 {
-    std::set<uint256> res; //set allows to avoid duplicates
+    std::vector<uint256> res;
 
     AssertLockHeld(cs);
 
@@ -306,7 +308,7 @@ std::set<uint256> CTxMemPool::mempoolDirectDescendantsOf(const CTransactionBase&
         if (it == mapNextTx.end())
             continue;
 
-        res.insert(it->second.ptx->GetHash());
+        res.push_back(it->second.ptx->GetHash());
     }
 
     // ... and, should root be a scCreationTx, also all fwds in mempool directed to sc created by root
@@ -325,19 +327,19 @@ std::set<uint256> CTxMemPool::mempoolDirectDescendantsOf(const CTransactionBase&
             if (mapSidechains.count(sc.GetScId()) == 0)
                 continue;
             for(const auto& fwdTxHash : mapSidechains.at(sc.GetScId()).fwdTransfersSet)
-                res.insert(fwdTxHash);
+                res.push_back(fwdTxHash);
         }
     }
     return res;
 }
 
-std::set<uint256> CTxMemPool::mempoolFullDescendantsOf(const CTransactionBase& origTx) const
+std::vector<uint256> CTxMemPool::mempoolFullDescendantsOf(const CTransactionBase& origTx) const
 {
     // it's Depth-First-Search on txes/certs Direct Acyclic Graph, having originTx as root.
 
     AssertLockHeld(cs);
 
-    std::set<uint256> res = mempoolDirectDescendantsOf(origTx);
+    std::vector<uint256> res = mempoolDirectDescendantsOf(origTx);
     std::deque<uint256> toVisit(res.begin(), res.end());
 
     while(!toVisit.empty())
@@ -351,12 +353,14 @@ std::set<uint256> CTxMemPool::mempoolFullDescendantsOf(const CTransactionBase& o
         } else
             assert(pCurrentRoot);
 
-        res.insert(toVisit.front());
         toVisit.pop_front();
+        if (std::find(res.begin(), res.end(), pCurrentRoot->GetHash()) == res.end())
+            res.push_back(pCurrentRoot->GetHash());
 
-        std::set<uint256> directDescendants = mempoolDirectDescendantsOf(*pCurrentRoot);
+        std::vector<uint256> directDescendants = mempoolDirectDescendantsOf(*pCurrentRoot);
         for(const uint256& dep : directDescendants)
-            if (std::find(toVisit.begin(), toVisit.end(),dep) == toVisit.end())
+            if ((std::find(toVisit.begin(), toVisit.end(),dep) == toVisit.end()) &&
+                (std::find(res.begin(), res.end(),dep) == res.end()))
                 toVisit.push_front(dep);
     }
 
@@ -366,14 +370,13 @@ std::set<uint256> CTxMemPool::mempoolFullDescendantsOf(const CTransactionBase& o
 void CTxMemPool::remove(const CTransactionBase& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive)
 {
     // Remove transaction from memory pool
- 
     LOCK(cs);
-    std::set<uint256> objToRemove;
+    std::vector<uint256> objToRemove{};
 
     if (fRecursive)
         objToRemove = mempoolFullDescendantsOf(origTx);
 
-    objToRemove.insert(origTx.GetHash());
+    objToRemove.insert(objToRemove.begin(), origTx.GetHash());
 
     for(const uint256& hash : objToRemove)
     {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -155,8 +155,8 @@ private:
     bool checkCertImmatureExpenditures(
         const CScCertificate& cert, const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight);
 
-    std::set<uint256> mempoolDirectAncestorsOf(const CTransactionBase& root) const;
-    std::set<uint256> mempoolDirectDescendantsOf(const CTransactionBase& root) const;
+    std::vector<uint256> mempoolDirectAncestorsOf(const CTransactionBase& root) const;
+    std::vector<uint256> mempoolDirectDescendantsOf(const CTransactionBase& root) const;
 
     std::map<uint256, std::shared_ptr<CTransactionBase> > mapRecentlyAddedTxBase;
     uint64_t nRecentlyAddedSequence = 0;
@@ -195,8 +195,8 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256& hash, const CCertificateMemPoolEntry &entry, bool fCurrentEstimate = true);
 
-    std::set<uint256> mempoolFullAncestorsOf(const CTransactionBase& origTx) const;
-    std::set<uint256> mempoolFullDescendantsOf(const CTransactionBase& origTx) const;
+    std::vector<uint256> mempoolFullAncestorsOf(const CTransactionBase& origTx) const;
+    std::vector<uint256> mempoolFullDescendantsOf(const CTransactionBase& origTx) const;
     void remove(const CTransactionBase& origTx, std::list<CTransaction>& removedTxs, std::list<CScCertificate>& removedCerts, bool fRecursive = false);
 
     void removeWithAnchor(const uint256 &invalidRoot);


### PR DESCRIPTION
Along code review suggestions, I have made a minor refactoring of `mempoolFullAncestorsOf ``mempoolFullDescendantsOf` in order to return a std::vector which preserves ancestors or descendants ordering.