### PR TITLE
Restoring ordering in DisconnectBlock

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1060,7 +1060,7 @@ bool CCoinsViewCache::HaveScRequirements(const CTransaction& tx, int height)
 
 #endif
 
-bool CCoinsViewCache::UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndoEntry, std::map<uint256, bool>* pVoidedCertsMap)
+bool CCoinsViewCache::UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndoEntry)
 {
     const uint256& certHash       = cert.GetHash();
     const uint256& scId           = cert.GetScId();
@@ -1078,10 +1078,10 @@ bool CCoinsViewCache::UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndo
 
     CSidechainsMap::iterator scIt = ModifySidechain(scId);
 
-    certUndoEntry.replacedLastCertEpoch     = scIt->second.scInfo.topCommittedCertReferencedEpoch;
-    certUndoEntry.replacedLastCertHash      = scIt->second.scInfo.topCommittedCertHash;
-    certUndoEntry.replacedLastCertQuality   = scIt->second.scInfo.topCommittedCertQuality;
-    certUndoEntry.replacedLastCertBwtAmount = scIt->second.scInfo.topCommittedCertBwtAmount;
+    certUndoEntry.prevTopCommittedCertReferencedEpoch = scIt->second.scInfo.topCommittedCertReferencedEpoch;
+    certUndoEntry.prevTopCommittedCertHash            = scIt->second.scInfo.topCommittedCertHash;
+    certUndoEntry.prevTopCommittedCertQuality         = scIt->second.scInfo.topCommittedCertQuality;
+    certUndoEntry.prevTopCommittedCertBwtAmount       = scIt->second.scInfo.topCommittedCertBwtAmount;
 
     if (scIt->second.scInfo.topCommittedCertReferencedEpoch != cert.epochNumber)
     {
@@ -1111,8 +1111,6 @@ bool CCoinsViewCache::UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndo
 
         LogPrint("cert", "%s():%d - cert quality set in scView (best cert=%s, best q=%d)\n", __func__, __LINE__,
         scIt->second.scInfo.topCommittedCertHash.ToString(), scIt->second.scInfo.topCommittedCertQuality);
-
-        CSidechain::SetVoidedCert(scIt->second.scInfo.topCommittedCertHash, false, pVoidedCertsMap);
     }
     else
     {
@@ -1132,17 +1130,12 @@ bool CCoinsViewCache::UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndo
                 return false;
             }
 
-            CSidechain::SetVoidedCert(scIt->second.scInfo.topCommittedCertHash, true, pVoidedCertsMap);
-
             // update top-quality certificate data
             scIt->second.scInfo.topCommittedCertHash      = certHash;
             scIt->second.scInfo.topCommittedCertQuality   = cert.quality;
             scIt->second.scInfo.topCommittedCertBwtAmount = bwtTotalAmount;
             LogPrint("cert", "%s():%d - cert quality updated in scView (best cert=%s, best q=%d)\n", __func__, __LINE__,
             scIt->second.scInfo.topCommittedCertHash.ToString(), scIt->second.scInfo.topCommittedCertQuality);
-
-            CSidechain::SetVoidedCert(scIt->second.scInfo.topCommittedCertHash, false, pVoidedCertsMap);
-          
             scIt->second.scInfo.balance -= bwtTotalAmount;
             LogPrint("cert", "%s():%d - amount removed from scView (amount=%s, resulting bal=%s) %s\n",
               __func__, __LINE__, FormatMoney(bwtTotalAmount), FormatMoney(scIt->second.scInfo.balance), scId.ToString());
@@ -1199,7 +1192,7 @@ void CCoinsViewCache::NullifyBackwardTransfers(const uint256& certHash, std::vec
 bool CCoinsViewCache::RestoreBackwardTransfers(const CTxUndo& certUndoEntry)
 {
     bool fClean = true;
-    const uint256& coinHash = certUndoEntry.replacedLastCertHash;
+    const uint256& coinHash = certUndoEntry.prevTopCommittedCertHash;
     LogPrint("cert", "%s():%d - called for cert %s\n", __func__, __LINE__, coinHash.ToString());
 
     CCoinsModifier coins = this->ModifyCoins(coinHash);
@@ -1240,7 +1233,7 @@ bool CCoinsViewCache::RestoreBackwardTransfers(const CTxUndo& certUndoEntry)
     return fClean;
 }
 
-bool CCoinsViewCache::RevertCertOutputs(const CScCertificate& cert, const CTxUndo &certUndoEntry, std::map<uint256, bool>* pVoidedCertsMap)
+bool CCoinsViewCache::RevertCertOutputs(const CScCertificate& cert, const CTxUndo &certUndoEntry)
 {
     const uint256& scId           = cert.GetScId();
     const CAmount& bwtTotalAmount = cert.GetValueOfBackwardTransfers();
@@ -1258,9 +1251,9 @@ bool CCoinsViewCache::RevertCertOutputs(const CScCertificate& cert, const CTxUnd
 
     // restore only if this is the top quality cert for this epoch
     LogPrint("cert", "%s():%d - cert %s, last cert %s, undo cert %s\n", __func__, __LINE__,
-        cert.GetHash().ToString(), scIt->second.scInfo.topCommittedCertHash.ToString(), certUndoEntry.replacedLastCertHash.ToString());
+        cert.GetHash().ToString(), scIt->second.scInfo.topCommittedCertHash.ToString(), certUndoEntry.prevTopCommittedCertHash.ToString());
     LogPrint("cert", "%s():%d - cert epoch %d, last epoch %d, undo epoch %d\n", __func__, __LINE__,
-        cert.epochNumber, scIt->second.scInfo.topCommittedCertReferencedEpoch, certUndoEntry.replacedLastCertEpoch);
+        cert.epochNumber, scIt->second.scInfo.topCommittedCertReferencedEpoch, certUndoEntry.prevTopCommittedCertReferencedEpoch);
 
     if (cert.GetHash() == scIt->second.scInfo.topCommittedCertHash)
     {
@@ -1272,61 +1265,27 @@ bool CCoinsViewCache::RevertCertOutputs(const CScCertificate& cert, const CTxUnd
 
         //if a lower quality certificate is restored, we have to subtract the relevant amount
         // from the balance
-        if (scIt->second.scInfo.topCommittedCertReferencedEpoch == certUndoEntry.replacedLastCertEpoch)
+        if (cert.epochNumber == certUndoEntry.prevTopCommittedCertReferencedEpoch)
         {
             // if we are restoring a cert for the same epoch it must have a lower quality than us
-            assert(cert.quality > certUndoEntry.replacedLastCertQuality);
+            assert(cert.quality > certUndoEntry.prevTopCommittedCertQuality);
 
             // certificate must resurrect its bacwardtransfers
             RestoreBackwardTransfers(certUndoEntry);
-            CSidechain::SetVoidedCert(certUndoEntry.replacedLastCertHash, false, pVoidedCertsMap);
-
-            // and void replaced cert
-            CSidechain::SetVoidedCert(scIt->second.scInfo.topCommittedCertHash, true, pVoidedCertsMap);
 
             // in this case we have to update the sc balance with undo amount
-            scIt->second.scInfo.balance -= certUndoEntry.replacedLastCertBwtAmount;
+            scIt->second.scInfo.balance -= certUndoEntry.prevTopCommittedCertBwtAmount;
         }
     }
 
-    scIt->second.scInfo.topCommittedCertReferencedEpoch = certUndoEntry.replacedLastCertEpoch;
-    scIt->second.scInfo.topCommittedCertHash            = certUndoEntry.replacedLastCertHash;
-    scIt->second.scInfo.topCommittedCertQuality         = certUndoEntry.replacedLastCertQuality;
-    scIt->second.scInfo.topCommittedCertBwtAmount       = certUndoEntry.replacedLastCertBwtAmount;
+    scIt->second.scInfo.topCommittedCertReferencedEpoch = certUndoEntry.prevTopCommittedCertReferencedEpoch;
+    scIt->second.scInfo.topCommittedCertHash            = certUndoEntry.prevTopCommittedCertHash;
+    scIt->second.scInfo.topCommittedCertQuality         = certUndoEntry.prevTopCommittedCertQuality;
+    scIt->second.scInfo.topCommittedCertBwtAmount       = certUndoEntry.prevTopCommittedCertBwtAmount;
 
     scIt->second.flag = CSidechainsCacheEntry::Flags::DIRTY;
 
     return true;
-}
-
-std::map<uint256,uint256> CCoinsViewCache::HighQualityCertDataFor(const CBlock& blockToConnect)
-{
-    // The function assumes that certs of given scId are ordered by increasing quality and
-    // reference all the same epoch as CheckBlock() guarantees.
-
-    // It's key that res[pos] carries the hash of the certificate made low quality by blockToConnect.vcert[pos]
-    // Should a cert in block NOT superseed another one, an empty hash will be placed
-
-    std::set<uint256> visitedScIds;
-    std::map<uint256,uint256> res;
-    for(auto itCert = blockToConnect.vcert.rbegin(); itCert != blockToConnect.vcert.rend(); ++itCert)
-    {
-    	if (visitedScIds.count(itCert->GetScId()) != 0)
-    		continue;
-
-        CSidechain sidechain;
-        if(!GetSidechain(itCert->GetScId(), sidechain))
-            continue;
-
-        if (itCert->epochNumber == sidechain.topCommittedCertReferencedEpoch)
-        	res[itCert->GetHash()] = sidechain.topCommittedCertHash;
-        else
-        	res[itCert->GetHash()] = uint256();
-
-    	visitedScIds.insert(itCert->GetScId());
-    }
-
-    return res;
 }
 
 bool CCoinsViewCache::HaveSidechainEvents(int height) const
@@ -1545,23 +1504,13 @@ bool CCoinsViewCache::CancelSidechainEvent(const CTxForwardTransferOut& forwardO
     return true;
 }
 
-bool CCoinsViewCache::CancelSidechainEvent(const CScCertificate& cert, const CTxUndo &certUndoEntry)
+bool CCoinsViewCache::CancelSidechainEvent(const CScCertificate& cert)
 {
     CSidechain restoredScInfo;
     if (!this->GetSidechain(cert.GetScId(), restoredScInfo)) {
         LogPrint("sc", "%s():%d - SIDECHAIN-EVENT:: attempt to undo ceasing sidechain map with cert to unknown scId[%s]\n",
             __func__, __LINE__, cert.GetScId().ToString());
         return false;
-    }
-
-    //LogPrint("sc", "%s():%d -------------- info -------------- \n", __func__, __LINE__);
-    //Dump_info();
-
-    if (certUndoEntry.replacedLastCertEpoch == cert.epochNumber)
-    {
-        LogPrint("sc", "%s():%d - nothing to do for scId[%s]: undo of cert [%s] / q[%d] does not change epoch\n",
-            __func__, __LINE__, cert.GetScId().ToString(), cert.GetHash().ToString(), cert.quality);
-        return true;
     }
 
     int currentCeasingHeight = restoredScInfo.StartHeightForEpoch(cert.epochNumber+2) + restoredScInfo.SafeguardMargin()+1;

--- a/src/coins.h
+++ b/src/coins.h
@@ -570,12 +570,11 @@ public:
     //CERTIFICATES RELATED PUBLIC MEMBERS
     bool IsCertApplicableToState(const CScCertificate& cert, int nHeight, CValidationState& state, libzendoomc::CScProofVerifier& scVerifier) const;
     bool isEpochDataValid(const CSidechain& scInfo, int epochNumber, const uint256& epochBlockHash) const;
-    bool UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndoEntry, std::map<uint256, bool>* pVoidedCertsMap = nullptr);
-    bool RevertCertOutputs(const CScCertificate& cert, const CTxUndo &certUndoEntry, std::map<uint256, bool>* pVoidedCertsMap = nullptr);
+    bool UpdateScInfo(const CScCertificate& cert, CTxUndo& certUndoEntry);
+    bool RevertCertOutputs(const CScCertificate& cert, const CTxUndo &certUndoEntry);
     bool CheckQuality(const CScCertificate& cert)  const override;
     void NullifyBackwardTransfers(const uint256& certHash, std::vector<CTxInUndo>& nullifiedOuts);
     bool RestoreBackwardTransfers(const CTxUndo& certUndoEntry);
-    std::map<uint256,uint256> HighQualityCertDataFor(const CBlock& blockToConnect);
 
     //SIDECHAINS EVENTS RELATED MEMBERS
     bool HaveSidechainEvents(int height)                            const override;
@@ -587,7 +586,7 @@ public:
 
     bool CancelSidechainEvent(const CTxScCreationOut& scCreationOut, int creationHeight);
     bool CancelSidechainEvent(const CTxForwardTransferOut& forwardOut, int fwdHeight);
-    bool CancelSidechainEvent(const CScCertificate& cert, const CTxUndo &certUndoEntry);
+    bool CancelSidechainEvent(const CScCertificate& cert);
 
     bool HandleSidechainEvents(int height, CBlockUndo& blockUndo, std::map<uint256, bool>* pVoidedCertsMap);
     bool RevertSidechainEvents(const CBlockUndo& blockUndo, int height, std::map<uint256, bool>* pVoidedCertsMap);

--- a/src/gtest/test_sidechain.cpp
+++ b/src/gtest/test_sidechain.cpp
@@ -499,8 +499,8 @@ TEST_F(SidechainTestSuite, CertificateUpdatesTopCommittedCertHash) {
     //check
     ASSERT_TRUE(sidechainsView->GetSidechain(scId,scInfo));
     EXPECT_TRUE(scInfo.topCommittedCertHash == aCertificate.GetHash());
-    EXPECT_TRUE(certUndoEntry.replacedLastCertEpoch == -1);
-    EXPECT_TRUE(certUndoEntry.replacedLastCertHash.IsNull());
+    EXPECT_TRUE(certUndoEntry.prevTopCommittedCertReferencedEpoch == -1);
+    EXPECT_TRUE(certUndoEntry.prevTopCommittedCertHash.IsNull());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/gtest/test_sidechain_events.cpp
+++ b/src/gtest/test_sidechain_events.cpp
@@ -876,11 +876,13 @@ TEST_F(SidechainsEventsTestSuite, UndoFullCertUpdatesToCeasingScs) {
 
     //Checks
     view->GetSidechain(scId, scInfo);
-
     EXPECT_FALSE(view->HaveSidechainEvents(newCeasingHeight));
     CSidechainEvents restoredCeasingScIds;
     EXPECT_TRUE(view->GetSidechainEvents(initialCeasingHeight,restoredCeasingScIds));
     EXPECT_TRUE(updatedCeasingScIds.ceasingScs.count(scId) != 0);
+
+    //check idempotency
+    EXPECT_TRUE(view->CancelSidechainEvent(cert));
 }
 
 TEST_F(SidechainsEventsTestSuite, UndoPureBwtCertUpdatesToCeasingScs) {
@@ -928,6 +930,9 @@ TEST_F(SidechainsEventsTestSuite, UndoPureBwtCertUpdatesToCeasingScs) {
     CSidechainEvents restoredCeasingScIds;
     EXPECT_TRUE(view->GetSidechainEvents(initialCeasingHeight,restoredCeasingScIds));
     EXPECT_TRUE(updatedCeasingScIds.ceasingScs.count(scId) != 0);
+
+    //check idempotency
+    EXPECT_TRUE(view->CancelSidechainEvent(cert));
 }
 
 TEST_F(SidechainsEventsTestSuite, UndoNoBwtCertUpdatesToCeasingScs) {
@@ -975,6 +980,9 @@ TEST_F(SidechainsEventsTestSuite, UndoNoBwtCertUpdatesToCeasingScs) {
     CSidechainEvents restoredCeasingScIds;
     EXPECT_TRUE(view->GetSidechainEvents(initialCeasingHeight,restoredCeasingScIds));
     EXPECT_TRUE(updatedCeasingScIds.ceasingScs.count(scId) != 0);
+
+    //check idempotency
+    EXPECT_TRUE(view->CancelSidechainEvent(cert));
 }
 
 TEST_F(SidechainsEventsTestSuite, UndoEmptyCertUpdatesToCeasingScs) {
@@ -1022,6 +1030,9 @@ TEST_F(SidechainsEventsTestSuite, UndoEmptyCertUpdatesToCeasingScs) {
     CSidechainEvents restoredCeasingScIds;
     EXPECT_TRUE(view->GetSidechainEvents(initialCeasingHeight,restoredCeasingScIds));
     EXPECT_TRUE(updatedCeasingScIds.ceasingScs.count(scId) != 0);
+
+    //check idempotency
+    EXPECT_TRUE(view->CancelSidechainEvent(cert));
 }
 ///////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// ApplyTxInUndo ////////////////////////////////

--- a/src/gtest/test_sidechain_events.cpp
+++ b/src/gtest/test_sidechain_events.cpp
@@ -872,7 +872,7 @@ TEST_F(SidechainsEventsTestSuite, UndoFullCertUpdatesToCeasingScs) {
 
     //test
     view->RevertCertOutputs(cert, dummyCertUndo);
-    view->CancelSidechainEvent(cert, dummyCertUndo);
+    view->CancelSidechainEvent(cert);
 
     //Checks
     view->GetSidechain(scId, scInfo);
@@ -919,7 +919,7 @@ TEST_F(SidechainsEventsTestSuite, UndoPureBwtCertUpdatesToCeasingScs) {
 
     //test
     view->RevertCertOutputs(cert, dummyCertUndo);
-    view->CancelSidechainEvent(cert, dummyCertUndo);
+    view->CancelSidechainEvent(cert);
 
     //Checks
     view->GetSidechain(scId, scInfo);
@@ -966,7 +966,7 @@ TEST_F(SidechainsEventsTestSuite, UndoNoBwtCertUpdatesToCeasingScs) {
 
     //test
     view->RevertCertOutputs(cert, dummyCertUndo);
-    view->CancelSidechainEvent(cert, dummyCertUndo);
+    view->CancelSidechainEvent(cert);
 
     //Checks
     view->GetSidechain(scId, scInfo);
@@ -1013,7 +1013,7 @@ TEST_F(SidechainsEventsTestSuite, UndoEmptyCertUpdatesToCeasingScs) {
 
     //test
     view->RevertCertOutputs(cert, dummyCertUndo);
-    view->CancelSidechainEvent(cert, dummyCertUndo);
+    view->CancelSidechainEvent(cert);
 
     //Checks
     view->GetSidechain(scId, scInfo);

--- a/src/main.h
+++ b/src/main.h
@@ -385,6 +385,9 @@ bool ApplyTxInUndo(const CTxInUndo& undo, CCoinsViewCache& view, const COutPoint
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache &inputs, CTxUndo& txundo, int nHeight);
 void UpdateCoins(const CScCertificate& cert, CCoinsViewCache &inputs, CTxUndo& txundo, int nHeight, bool fVoidBwts);
 
+std::map<uint256,uint256> HighQualityCertData(const CBlock& blockToConnect, const CCoinsViewCache& view);
+std::map<uint256,uint256> HighQualityCertData(const CBlock& blockToDisconnect, const CBlockUndo& blockUndo);
+
 /** Context-independent validity checks */
 bool CheckTransaction(const CTransaction& tx, CValidationState& state, libzcash::ProofVerifier& verifier);
 bool CheckCertificate(const CScCertificate& cert, CValidationState& state);
@@ -477,7 +480,6 @@ bool TestBlockValidity(CValidationState &state, const CBlock& block, CBlockIndex
  */
 bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex **pindex, bool fRequested, CDiskBlockPos* dbp, BlockSet* sForkTips = NULL);
 bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex **ppindex= NULL, bool lookForwardTips = false);
-
 
 
 class CBlockFileInfo

--- a/src/undo.h
+++ b/src/undo.h
@@ -123,15 +123,15 @@ public:
     std::vector<CTxInUndo> vprevout; // undo information for all txins
 
     //for cert only, to restore ScInfo
-    int replacedLastCertEpoch;
-    uint256 replacedLastCertHash;
-    int64_t replacedLastCertQuality;
-    CAmount replacedLastCertBwtAmount;
+    int prevTopCommittedCertReferencedEpoch;
+    uint256 prevTopCommittedCertHash;
+    int64_t prevTopCommittedCertQuality;
+    CAmount prevTopCommittedCertBwtAmount;
     std::vector<CTxInUndo> vBwts; // undo information for bwt
 
-    CTxUndo(): vprevout(), replacedLastCertEpoch(CScCertificate::EPOCH_NOT_INITIALIZED),
-            replacedLastCertHash(), replacedLastCertQuality(CScCertificate::QUALITY_NOT_INITIALIZED),
-            replacedLastCertBwtAmount(0), vBwts() {}
+    CTxUndo(): vprevout(), prevTopCommittedCertReferencedEpoch(CScCertificate::EPOCH_NOT_INITIALIZED),
+            prevTopCommittedCertHash(), prevTopCommittedCertQuality(CScCertificate::QUALITY_NOT_INITIALIZED),
+            prevTopCommittedCertBwtAmount(0), vBwts() {}
 
     size_t GetSerializeSize(int nType, int nVersion) const
     {
@@ -143,13 +143,13 @@ public:
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const
     {
-        if (replacedLastCertEpoch != CScCertificate::EPOCH_NOT_INITIALIZED) {
+        if (prevTopCommittedCertReferencedEpoch != CScCertificate::EPOCH_NOT_INITIALIZED) {
             WriteCompactSize(s, certAttributesMarker);
             ::Serialize(s, vprevout,                  nType, nVersion);
-            ::Serialize(s, replacedLastCertEpoch,     nType, nVersion);
-            ::Serialize(s, replacedLastCertHash,      nType, nVersion);
-            ::Serialize(s, replacedLastCertQuality,   nType, nVersion);
-            ::Serialize(s, replacedLastCertBwtAmount, nType, nVersion);
+            ::Serialize(s, prevTopCommittedCertReferencedEpoch,     nType, nVersion);
+            ::Serialize(s, prevTopCommittedCertHash,      nType, nVersion);
+            ::Serialize(s, prevTopCommittedCertQuality,   nType, nVersion);
+            ::Serialize(s, prevTopCommittedCertBwtAmount, nType, nVersion);
             ::Serialize(s, vBwts,                     nType, nVersion);
         }
         else {
@@ -162,20 +162,20 @@ public:
     {
         // reading from data stream to memory
         vprevout.clear();
-        replacedLastCertEpoch = CScCertificate::EPOCH_NOT_INITIALIZED;
-        replacedLastCertHash.SetNull();
-        replacedLastCertQuality = CScCertificate::QUALITY_NOT_INITIALIZED;
-        replacedLastCertBwtAmount = 0;
+        prevTopCommittedCertReferencedEpoch = CScCertificate::EPOCH_NOT_INITIALIZED;
+        prevTopCommittedCertHash.SetNull();
+        prevTopCommittedCertQuality = CScCertificate::QUALITY_NOT_INITIALIZED;
+        prevTopCommittedCertBwtAmount = 0;
         vBwts.clear();
 
         unsigned int nSize = ReadCompactSize(s);
         if (nSize == certAttributesMarker)
         {
             ::Unserialize(s, vprevout, nType, nVersion);
-            ::Unserialize(s, replacedLastCertEpoch,     nType, nVersion);
-            ::Unserialize(s, replacedLastCertHash,      nType, nVersion);
-            ::Unserialize(s, replacedLastCertQuality,   nType, nVersion);
-            ::Unserialize(s, replacedLastCertBwtAmount, nType, nVersion);
+            ::Unserialize(s, prevTopCommittedCertReferencedEpoch,     nType, nVersion);
+            ::Unserialize(s, prevTopCommittedCertHash,      nType, nVersion);
+            ::Unserialize(s, prevTopCommittedCertQuality,   nType, nVersion);
+            ::Unserialize(s, prevTopCommittedCertBwtAmount, nType, nVersion);
             ::Unserialize(s, vBwts,                     nType, nVersion);
         }
         else
@@ -188,10 +188,10 @@ public:
         str += strprintf("vprevout.size %u\n", vprevout.size());
         for(const CTxInUndo& in: vprevout)
             str += strprintf("\n  [%s]\n", in.ToString());
-        str += strprintf("replacedLastCertEpoch     %d\n", replacedLastCertEpoch);
-        str += strprintf("replacedLastCertHash      %s\n", replacedLastCertHash.ToString());
-        str += strprintf("replacedLastCertQuality   %d\n", replacedLastCertQuality);
-        str += strprintf("replacedLastCertBwtAmount %d\n", replacedLastCertBwtAmount);
+        str += strprintf("prevTopCommittedCertReferencedEpoch     %d\n", prevTopCommittedCertReferencedEpoch);
+        str += strprintf("prevTopCommittedCertHash      %s\n", prevTopCommittedCertHash.ToString());
+        str += strprintf("prevTopCommittedCertQuality   %d\n", prevTopCommittedCertQuality);
+        str += strprintf("prevTopCommittedCertBwtAmount %d\n", prevTopCommittedCertBwtAmount);
         str += strprintf("vBwts.size %u\n", vBwts.size());
         for(const CTxInUndo& x: vBwts)
             str += strprintf("\n  [%s]\n", x.ToString());


### PR DESCRIPTION
Refactored code to allow operation ordering in DisconnectBlock (cancel sc events then restore sc state) to be reversed wrt ConnectBlock (update sc state then schedule sc events)