### PR TITLE
Introduction of ad-hoc type for ScTxsCommitment

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -183,7 +183,7 @@ public:
     //! block header
     int nVersion;
     uint256 hashMerkleRoot;
-    uint256 hashScTxsCommitment;
+    CFakePoseidonHash hashScTxsCommitment;
     unsigned int nTime;
     unsigned int nBits;
     uint256 nNonce;
@@ -214,7 +214,7 @@ public:
 
         nVersion       = 0;
         hashMerkleRoot = uint256();
-        hashScTxsCommitment = uint256();
+        hashScTxsCommitment.SetNull();
         nTime          = 0;
         nBits          = 0;
         nNonce         = uint256();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3025,7 +3025,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     {
         const uint256& scTxsCommittment = scCommitmentBuilder.getCommitment();
 
-        if (block.hashScTxsCommitment != scTxsCommittment)
+        if (block.hashScTxsCommitment != CFakePoseidonHash(scTxsCommittment))
         {
             // If this check fails, we return validation state obj with a state.corruptionPossible=false attribute,
             // which will mark this header as failed. This is because the previous check on merkel root was successful,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -731,7 +731,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-        pblock->hashScTxsCommitment = pblock->BuildScTxsCommitment();
+        pblock->hashScTxsCommitment = CFakePoseidonHash(pblock->BuildScTxsCommitment());
         UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
         pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, Params().GetConsensus());
         pblock->nSolution.clear();

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -8,6 +8,7 @@
 
 #include "primitives/transaction.h"
 #include "primitives/certificate.h"
+#include "sc/sidechaintypes.h"
 #include "serialize.h"
 #include "uint256.h"
 
@@ -30,7 +31,7 @@ public:
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
-    uint256 hashScTxsCommitment;
+    CFakePoseidonHash hashScTxsCommitment;
     uint32_t nTime;
     uint32_t nBits;
     uint256 nNonce;

--- a/src/sc/sidechaintypes.h
+++ b/src/sc/sidechaintypes.h
@@ -11,11 +11,34 @@
 #include "serialize.h"
 #include <boost/unordered_map.hpp>
 #include <boost/variant.hpp>
-
 #include<sc/proofverifier.h>
 
-//------------------------------------------------------------------------------------
 class CTxForwardTransferOut;
+
+class CFakePoseidonHash
+{
+public:
+    CFakePoseidonHash()  {SetNull();};
+    explicit CFakePoseidonHash(const uint256& sha256): innerHash(sha256) {} //UPON INTEGRATION OF POSEIDON HASH STUFF, THIS MUST DISAPPER
+    ~CFakePoseidonHash() = default;
+
+    void SetNull() { innerHash.SetNull(); }
+    friend inline bool operator==(const CFakePoseidonHash& lhs, const CFakePoseidonHash& rhs) { return lhs.innerHash == rhs.innerHash; }
+    friend inline bool operator!=(const CFakePoseidonHash& lhs, const CFakePoseidonHash& rhs) { return !(lhs == rhs); }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(innerHash);
+    }
+
+    std::string GetHex() const   {return innerHash.GetHex();}
+    std::string ToString() const {return innerHash.ToString();}
+
+private:
+    uint256 innerHash; //Temporary, for backward compatibility with beta
+};
 
 namespace Sidechain
 {


### PR DESCRIPTION
Currently ScTxsCommitment is a uint256 type. This will change soon and probably multiple times. These PR introduce a new type for ScTxsCommitment. It is called CFakePoseidonHash, it simply wraps uint256, introducing an interface which should make subsequent changes to ScTxsCommitment much simpler.

Currently the PR targets sidechain_dev