### PR TITLE
Sidechains integration step4 batch verification improvement

### DIFF
--- a/qa/rpc-tests/sc_async_proof_verifier.py
+++ b/qa/rpc-tests/sc_async_proof_verifier.py
@@ -46,13 +46,14 @@ class AsyncProofVerifierTest(BitcoinTestFramework):
 
     def setup_network(self, split=False):
         self.nodes = start_nodes(NUMB_OF_NODES, self.options.tmpdir,
-                                 extra_args=[["-forcelocalban", "-sccoinsmaturity=0", '-scproofqueuesize=10', '-logtimemicros=1', '-debug=sc',
-                                              '-debug=py', '-debug=mempool', '-debug=net', '-debug=bench'],
-                                             ["-forcelocalban", "-sccoinsmaturity=0", '-scproofqueuesize=10', '-logtimemicros=1', '-debug=sc',
-                                              '-debug=py', '-debug=mempool', '-debug=net', '-debug=bench'],
+                                 extra_args=[["-forcelocalban", "-sccoinsmaturity=0", '-logtimemicros=1', '-debug=sc',
+                                              '-debug=py', '-debug=mempool', '-debug=net', '-debug=bench', '-debug=cert'],
+                                             ["-forcelocalban", "-sccoinsmaturity=0", '-logtimemicros=1', '-debug=sc',
+                                              '-debug=py', '-debug=mempool', '-debug=net', '-debug=bench', '-debug=cert'],
                                              # Skip proof verification for the last node
-                                             ["-forcelocalban", "-skipscproof", "-sccoinsmaturity=0", '-scproofqueuesize=10', '-logtimemicros=1',
-                                              '-debug=sc', '-debug=py', '-debug=mempool', '-debug=net', '-debug=bench']])
+                                             ["-forcelocalban", "-skipscproof", "-sccoinsmaturity=0", '-logtimemicros=1',
+                                              '-debug=sc', '-debug=py', '-debug=mempool', '-debug=net', '-debug=bench',
+                                              '-debug=cert']])
 
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)

--- a/src/gtest/test_asyncproofverifier.cpp
+++ b/src/gtest/test_asyncproofverifier.cpp
@@ -486,9 +486,9 @@ TEST_F(AsyncProofVerifierTestSuite, Check_One_By_One_Verification)
  */
 TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
 {
-    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierItem>> cswEnqueuedData;
+    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> cswEnqueuedData;
 
-    std::map</*outputPos*/unsigned int, CCswProofVerifierItem> element;
+    std::map</*outputPos*/unsigned int, CCswProofVerifierInput> element;
 
     CTxCeasedSidechainWithdrawalInput cswInput1, cswInput2;
 
@@ -498,11 +498,11 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
 
     CTransaction cswTransaction = cswMutTransaction;
 
-    std::vector<CCswProofVerifierItem> inputs;
+    std::vector<CCswProofVerifierInput> inputs;
 
     for (int i = 0; i < cswMutTransaction.vcsw_ccin.size(); i++)
     {
-        CCswProofVerifierItem input;
+        CCswProofVerifierInput input;
         input.verificationKey = CScVKey{SAMPLE_CSW_DARLIN_VK},
         input.ceasingCumScTxCommTree = cswInput1.ceasingCumScTxCommTree,
         input.certDataHash = cswInput1.actCertDataHash,
@@ -521,7 +521,7 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
     
     cswEnqueuedData.insert(std::make_pair(uint256S("aaaa"), element));
 
-    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierItem>> tempQueue;
+    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> tempQueue;
 
     ASSERT_EQ(tempQueue.size(), 0);
     ASSERT_EQ(cswEnqueuedData.size(), 1);
@@ -534,7 +534,7 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
     ASSERT_EQ(tempQueue.size(), 1);
     ASSERT_EQ(tempQueue.begin()->first, uint256S("aaaa"));
 
-    std::map</*outputPos*/unsigned int, CCswProofVerifierItem> tempElement = tempQueue.begin()->second;
+    std::map</*outputPos*/unsigned int, CCswProofVerifierInput> tempElement = tempQueue.begin()->second;
     ASSERT_EQ(tempElement.size(), 2);
     
     for (int i = 0; i < tempElement.size(); i++)

--- a/src/gtest/test_asyncproofverifier.cpp
+++ b/src/gtest/test_asyncproofverifier.cpp
@@ -507,12 +507,10 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
         input.ceasingCumScTxCommTree = cswInput1.ceasingCumScTxCommTree,
         input.certDataHash = cswInput1.actCertDataHash,
         input.proof = cswInput1.scProof,
-        input.node = &dummyNode,
         input.nValue = cswInput1.nValue,
         input.nullifier = cswInput1.nullifier,
         input.pubKeyHash = cswInput1.pubKeyHash,
         input.scId = cswInput1.scId,
-        input.parentPtr = std::make_shared<CTransaction>(cswTransaction);
 
         inputs.push_back(input);
         element.insert(std::make_pair(i, input));
@@ -543,10 +541,8 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
         ASSERT_EQ(tempElement.at(i).ceasingCumScTxCommTree, inputs.at(i).ceasingCumScTxCommTree);
         ASSERT_EQ(tempElement.at(i).certDataHash, inputs.at(i).certDataHash);
         ASSERT_EQ(tempElement.at(i).proof, inputs.at(i).proof);
-        ASSERT_EQ(tempElement.at(i).node, inputs.at(i).node);
         ASSERT_EQ(tempElement.at(i).nValue, inputs.at(i).nValue);
         ASSERT_EQ(tempElement.at(i).pubKeyHash, inputs.at(i).pubKeyHash);
         ASSERT_EQ(tempElement.at(i).scId, inputs.at(i).scId);
-        ASSERT_EQ(tempElement.at(i).parentPtr, inputs.at(i).parentPtr);
     }
 }

--- a/src/gtest/test_asyncproofverifier.cpp
+++ b/src/gtest/test_asyncproofverifier.cpp
@@ -486,9 +486,9 @@ TEST_F(AsyncProofVerifierTestSuite, Check_One_By_One_Verification)
  */
 TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
 {
-    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> cswEnqueuedData;
+    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierItem>> cswEnqueuedData;
 
-    std::map</*outputPos*/unsigned int, CCswProofVerifierInput> element;
+    std::map</*outputPos*/unsigned int, CCswProofVerifierItem> element;
 
     CTxCeasedSidechainWithdrawalInput cswInput1, cswInput2;
 
@@ -498,20 +498,21 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
 
     CTransaction cswTransaction = cswMutTransaction;
 
-    std::vector<CCswProofVerifierInput> inputs;
+    std::vector<CCswProofVerifierItem> inputs;
 
     for (int i = 0; i < cswMutTransaction.vcsw_ccin.size(); i++)
     {
-        CCswProofVerifierInput input = { .ceasedVk = CScVKey{SAMPLE_CSW_DARLIN_VK},
-                                         .ceasingCumScTxCommTree = cswInput1.ceasingCumScTxCommTree,
-                                         .certDataHash = cswInput1.actCertDataHash,
-                                         .cswProof = cswInput1.scProof,
-                                         .node = &dummyNode,
-                                         .nValue = cswInput1.nValue,
-                                         .nullifier = cswInput1.nullifier,
-                                         .pubKeyHash = cswInput1.pubKeyHash,
-                                         .scId = cswInput1.scId,
-                                         .transactionPtr = std::make_shared<CTransaction>(cswTransaction)};
+        CCswProofVerifierItem input;
+        input.verificationKey = CScVKey{SAMPLE_CSW_DARLIN_VK},
+        input.ceasingCumScTxCommTree = cswInput1.ceasingCumScTxCommTree,
+        input.certDataHash = cswInput1.actCertDataHash,
+        input.proof = cswInput1.scProof,
+        input.node = &dummyNode,
+        input.nValue = cswInput1.nValue,
+        input.nullifier = cswInput1.nullifier,
+        input.pubKeyHash = cswInput1.pubKeyHash,
+        input.scId = cswInput1.scId,
+        input.parentPtr = std::make_shared<CTransaction>(cswTransaction);
 
         inputs.push_back(input);
         element.insert(std::make_pair(i, input));
@@ -520,7 +521,7 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
     
     cswEnqueuedData.insert(std::make_pair(uint256S("aaaa"), element));
 
-    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> tempQueue;
+    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierItem>> tempQueue;
 
     ASSERT_EQ(tempQueue.size(), 0);
     ASSERT_EQ(cswEnqueuedData.size(), 1);
@@ -533,19 +534,19 @@ TEST_F(AsyncProofVerifierTestSuite, Csw_Queue_Move)
     ASSERT_EQ(tempQueue.size(), 1);
     ASSERT_EQ(tempQueue.begin()->first, uint256S("aaaa"));
 
-    std::map</*outputPos*/unsigned int, CCswProofVerifierInput> tempElement = tempQueue.begin()->second;
+    std::map</*outputPos*/unsigned int, CCswProofVerifierItem> tempElement = tempQueue.begin()->second;
     ASSERT_EQ(tempElement.size(), 2);
     
     for (int i = 0; i < tempElement.size(); i++)
     {
-        ASSERT_EQ(tempElement.at(i).ceasedVk, inputs.at(i).ceasedVk);
+        ASSERT_EQ(tempElement.at(i).verificationKey, inputs.at(i).verificationKey);
         ASSERT_EQ(tempElement.at(i).ceasingCumScTxCommTree, inputs.at(i).ceasingCumScTxCommTree);
         ASSERT_EQ(tempElement.at(i).certDataHash, inputs.at(i).certDataHash);
-        ASSERT_EQ(tempElement.at(i).cswProof, inputs.at(i).cswProof);
+        ASSERT_EQ(tempElement.at(i).proof, inputs.at(i).proof);
         ASSERT_EQ(tempElement.at(i).node, inputs.at(i).node);
         ASSERT_EQ(tempElement.at(i).nValue, inputs.at(i).nValue);
         ASSERT_EQ(tempElement.at(i).pubKeyHash, inputs.at(i).pubKeyHash);
         ASSERT_EQ(tempElement.at(i).scId, inputs.at(i).scId);
-        ASSERT_EQ(tempElement.at(i).transactionPtr, inputs.at(i).transactionPtr);
+        ASSERT_EQ(tempElement.at(i).parentPtr, inputs.at(i).parentPtr);
     }
 }

--- a/src/gtest/test_libzendoo.cpp
+++ b/src/gtest/test_libzendoo.cpp
@@ -77,9 +77,9 @@ static CMutableScCertificate CreateDefaultCert()
     return mcert;
 }
 
-static CCertProofVerifierInput CreateDefaultCertInput()
+static CCertProofVerifierItem CreateDefaultCertInput()
 {
-    CCertProofVerifierInput certInput;
+    CCertProofVerifierItem certInput;
 
     certInput.constant = CFieldElement(SAMPLE_FIELD);
     certInput.epochNumber = 7;
@@ -91,9 +91,9 @@ static CCertProofVerifierInput CreateDefaultCertInput()
     return certInput;
 }
 
-static CCswProofVerifierInput CreateDefaultCswInput()
+static CCswProofVerifierItem CreateDefaultCswInput()
 {
-    CCswProofVerifierInput cswInput;
+    CCswProofVerifierItem cswInput;
 
     cswInput.ceasingCumScTxCommTree = CFieldElement(SAMPLE_FIELD);
     cswInput.certDataHash = CFieldElement(SAMPLE_FIELD);
@@ -1645,9 +1645,9 @@ TEST(CctpLibrary, CreateAndVerifyMarlinCertificateProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCertProofVerifierInput certInput = CreateDefaultCertInput();
-    certInput.CertVk = testManager.GetTestVerificationKey(provingSystem, circuitType);
-    certInput.certProof = testManager.GenerateTestCertificateProof(certInput, provingSystem);
+    CCertProofVerifierItem certInput = CreateDefaultCertInput();
+    certInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
+    certInput.proof = testManager.GenerateTestCertificateProof(certInput, provingSystem);
 
     ASSERT_TRUE(testManager.VerifyCertificateProof(certInput));
 }
@@ -1667,9 +1667,9 @@ TEST(CctpLibrary, CreateAndVerifyDarlinCertificateProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCertProofVerifierInput certInput = CreateDefaultCertInput();
-    certInput.CertVk = testManager.GetTestVerificationKey(provingSystem, circuitType);
-    certInput.certProof = testManager.GenerateTestCertificateProof(certInput, provingSystem);
+    CCertProofVerifierItem certInput = CreateDefaultCertInput();
+    certInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
+    certInput.proof = testManager.GenerateTestCertificateProof(certInput, provingSystem);
 
     ASSERT_TRUE(testManager.VerifyCertificateProof(certInput));
 }
@@ -1689,9 +1689,9 @@ TEST(CctpLibrary, CreateAndVerifyMarlinCswProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCswProofVerifierInput cswInput = CreateDefaultCswInput();
-    cswInput.ceasedVk = testManager.GetTestVerificationKey(provingSystem, circuitType);
-    cswInput.cswProof = testManager.GenerateTestCswProof(cswInput, provingSystem);
+    CCswProofVerifierItem cswInput = CreateDefaultCswInput();
+    cswInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
+    cswInput.proof = testManager.GenerateTestCswProof(cswInput, provingSystem);
 
     ASSERT_TRUE(testManager.VerifyCswProof(cswInput));
 }
@@ -1711,9 +1711,9 @@ TEST(CctpLibrary, CreateAndVerifyDarlinCswProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCswProofVerifierInput cswInput = CreateDefaultCswInput();
-    cswInput.ceasedVk = testManager.GetTestVerificationKey(provingSystem, circuitType);
-    cswInput.cswProof = testManager.GenerateTestCswProof(cswInput, provingSystem);
+    CCswProofVerifierItem cswInput = CreateDefaultCswInput();
+    cswInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
+    cswInput.proof = testManager.GenerateTestCswProof(cswInput, provingSystem);
 
     ASSERT_TRUE(testManager.VerifyCswProof(cswInput));
 }

--- a/src/gtest/test_libzendoo.cpp
+++ b/src/gtest/test_libzendoo.cpp
@@ -77,9 +77,9 @@ static CMutableScCertificate CreateDefaultCert()
     return mcert;
 }
 
-static CCertProofVerifierItem CreateDefaultCertInput()
+static CCertProofVerifierInput CreateDefaultCertInput()
 {
-    CCertProofVerifierItem certInput;
+    CCertProofVerifierInput certInput;
 
     certInput.constant = CFieldElement(SAMPLE_FIELD);
     certInput.epochNumber = 7;
@@ -91,9 +91,9 @@ static CCertProofVerifierItem CreateDefaultCertInput()
     return certInput;
 }
 
-static CCswProofVerifierItem CreateDefaultCswInput()
+static CCswProofVerifierInput CreateDefaultCswInput()
 {
-    CCswProofVerifierItem cswInput;
+    CCswProofVerifierInput cswInput;
 
     cswInput.ceasingCumScTxCommTree = CFieldElement(SAMPLE_FIELD);
     cswInput.certDataHash = CFieldElement(SAMPLE_FIELD);
@@ -1645,7 +1645,7 @@ TEST(CctpLibrary, CreateAndVerifyMarlinCertificateProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCertProofVerifierItem certInput = CreateDefaultCertInput();
+    CCertProofVerifierInput certInput = CreateDefaultCertInput();
     certInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
     certInput.proof = testManager.GenerateTestCertificateProof(certInput, provingSystem);
 
@@ -1667,7 +1667,7 @@ TEST(CctpLibrary, CreateAndVerifyDarlinCertificateProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCertProofVerifierItem certInput = CreateDefaultCertInput();
+    CCertProofVerifierInput certInput = CreateDefaultCertInput();
     certInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
     certInput.proof = testManager.GenerateTestCertificateProof(certInput, provingSystem);
 
@@ -1689,7 +1689,7 @@ TEST(CctpLibrary, CreateAndVerifyMarlinCswProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCswProofVerifierItem cswInput = CreateDefaultCswInput();
+    CCswProofVerifierInput cswInput = CreateDefaultCswInput();
     cswInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
     cswInput.proof = testManager.GenerateTestCswProof(cswInput, provingSystem);
 
@@ -1711,7 +1711,7 @@ TEST(CctpLibrary, CreateAndVerifyDarlinCswProof)
 
     std::cout << "Temp folder for proof verification test: " << testManager.TempFolderPath() << std::endl;
 
-    CCswProofVerifierItem cswInput = CreateDefaultCswInput();
+    CCswProofVerifierInput cswInput = CreateDefaultCswInput();
     cswInput.verificationKey = testManager.GetTestVerificationKey(provingSystem, circuitType);
     cswInput.proof = testManager.GenerateTestCswProof(cswInput, provingSystem);
 

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -505,7 +505,7 @@ CTxCeasedSidechainWithdrawalInput BlockchainTestManager::CreateCswInput(uint256 
     CSidechain sidechain;
     assert(viewCache->GetSidechain(scId, sidechain));
 
-    CCswProofVerifierItem verifierInput = CScProofVerifier::CswInputToVerifierItem(input, nullptr, sidechain.fixedParams, nullptr);
+    CCswProofVerifierInput verifierInput = CScProofVerifier::CswInputToVerifierItem(input, nullptr, sidechain.fixedParams, nullptr);
     input.scProof = GenerateTestCswProof(verifierInput, provingSystem);
 
     return input;
@@ -586,7 +586,7 @@ CScCertificate BlockchainTestManager::GenerateCertificate(uint256 scId, int epoc
     CSidechain sidechain;
     assert(viewCache->GetSidechain(scId, sidechain));
 
-    CCertProofVerifierItem input = CScProofVerifier::CertificateToVerifierItem(res, sidechain.fixedParams, nullptr);
+    CCertProofVerifierInput input = CScProofVerifier::CertificateToVerifierItem(res, sidechain.fixedParams, nullptr);
     res.scProof = GenerateTestCertificateProof(input, provingSystem);
 
     return res;
@@ -615,7 +615,7 @@ void BlockchainTestManager::GenerateSidechainTestParameters(ProvingSystem provin
  * @param provingSystem The proving system to use for the proof generation
  * @return CScProof The generated proof.
  */
-CScProof BlockchainTestManager::GenerateTestCertificateProof(CCertProofVerifierItem certificate, ProvingSystem provingSystem) const
+CScProof BlockchainTestManager::GenerateTestCertificateProof(CCertProofVerifierInput certificate, ProvingSystem provingSystem) const
 {
     wrappedFieldPtr sptrConst = certificate.constant.GetFieldElement();
     wrappedFieldPtr sptrCum   = certificate.endEpochCumScTxCommTreeRoot.GetFieldElement();
@@ -682,7 +682,7 @@ CScProof BlockchainTestManager::GenerateTestCertificateProof(CCertProofVerifierI
  * @param provingSystem The proving system to use for the proof generation
  * @return CScProof The generated proof.
  */
-CScProof BlockchainTestManager::GenerateTestCswProof(CCswProofVerifierItem csw, ProvingSystem provingSystem) const
+CScProof BlockchainTestManager::GenerateTestCswProof(CCswProofVerifierInput csw, ProvingSystem provingSystem) const
 {
     wrappedFieldPtr sptrScId = CFieldElement(csw.scId).GetFieldElement();
     field_t* scidFe = sptrScId.get();
@@ -750,7 +750,7 @@ void BlockchainTestManager::StoreSidechainWithCurrentHeight(const uint256& scId,
  * @return true If the certificate proof is correctly verified.
  * @return false If the certificate proof is not valid.
  */
-bool BlockchainTestManager::VerifyCertificateProof(CCertProofVerifierItem certificate) const
+bool BlockchainTestManager::VerifyCertificateProof(CCertProofVerifierInput certificate) const
 {
     wrappedFieldPtr   sptrConst  = certificate.constant.GetFieldElement();
     wrappedFieldPtr   sptrCum    = certificate.endEpochCumScTxCommTreeRoot.GetFieldElement();
@@ -810,7 +810,7 @@ bool BlockchainTestManager::VerifyCertificateProof(CCertProofVerifierItem certif
  * @return true If the CSW input proof is correctly verified.
  * @return false If the CSW input proof is not valid.
  */
-bool BlockchainTestManager::VerifyCswProof(CCswProofVerifierItem csw) const
+bool BlockchainTestManager::VerifyCswProof(CCswProofVerifierInput csw) const
 {
     wrappedFieldPtr sptrScId = CFieldElement(csw.scId).GetFieldElement();
     field_t* scidFe = sptrScId.get();

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -505,7 +505,7 @@ CTxCeasedSidechainWithdrawalInput BlockchainTestManager::CreateCswInput(uint256 
     CSidechain sidechain;
     assert(viewCache->GetSidechain(scId, sidechain));
 
-    CCswProofVerifierInput verifierInput = SidechainProofVerifier::CswInputToVerifierInput(input, nullptr, sidechain.fixedParams, nullptr);
+    CCswProofVerifierInput verifierInput = CScProofVerifier::CswInputToVerifierInput(input, nullptr, sidechain.fixedParams, nullptr);
     input.scProof = GenerateTestCswProof(verifierInput, provingSystem);
 
     return input;
@@ -586,7 +586,7 @@ CScCertificate BlockchainTestManager::GenerateCertificate(uint256 scId, int epoc
     CSidechain sidechain;
     assert(viewCache->GetSidechain(scId, sidechain));
 
-    CCertProofVerifierInput input = SidechainProofVerifier::CertificateToVerifierInput(res, sidechain.fixedParams, nullptr);
+    CCertProofVerifierInput input = CScProofVerifier::CertificateToVerifierInput(res, sidechain.fixedParams, nullptr);
     res.scProof = GenerateTestCertificateProof(input, provingSystem);
 
     return res;

--- a/src/gtest/tx_creation_utils.cpp
+++ b/src/gtest/tx_creation_utils.cpp
@@ -505,7 +505,7 @@ CTxCeasedSidechainWithdrawalInput BlockchainTestManager::CreateCswInput(uint256 
     CSidechain sidechain;
     assert(viewCache->GetSidechain(scId, sidechain));
 
-    CCswProofVerifierInput verifierInput = CScProofVerifier::CswInputToVerifierInput(input, nullptr, sidechain.fixedParams, nullptr);
+    CCswProofVerifierItem verifierInput = CScProofVerifier::CswInputToVerifierItem(input, nullptr, sidechain.fixedParams, nullptr);
     input.scProof = GenerateTestCswProof(verifierInput, provingSystem);
 
     return input;
@@ -586,7 +586,7 @@ CScCertificate BlockchainTestManager::GenerateCertificate(uint256 scId, int epoc
     CSidechain sidechain;
     assert(viewCache->GetSidechain(scId, sidechain));
 
-    CCertProofVerifierInput input = CScProofVerifier::CertificateToVerifierInput(res, sidechain.fixedParams, nullptr);
+    CCertProofVerifierItem input = CScProofVerifier::CertificateToVerifierItem(res, sidechain.fixedParams, nullptr);
     res.scProof = GenerateTestCertificateProof(input, provingSystem);
 
     return res;
@@ -615,7 +615,7 @@ void BlockchainTestManager::GenerateSidechainTestParameters(ProvingSystem provin
  * @param provingSystem The proving system to use for the proof generation
  * @return CScProof The generated proof.
  */
-CScProof BlockchainTestManager::GenerateTestCertificateProof(CCertProofVerifierInput certificate, ProvingSystem provingSystem) const
+CScProof BlockchainTestManager::GenerateTestCertificateProof(CCertProofVerifierItem certificate, ProvingSystem provingSystem) const
 {
     wrappedFieldPtr sptrConst = certificate.constant.GetFieldElement();
     wrappedFieldPtr sptrCum   = certificate.endEpochCumScTxCommTreeRoot.GetFieldElement();
@@ -682,7 +682,7 @@ CScProof BlockchainTestManager::GenerateTestCertificateProof(CCertProofVerifierI
  * @param provingSystem The proving system to use for the proof generation
  * @return CScProof The generated proof.
  */
-CScProof BlockchainTestManager::GenerateTestCswProof(CCswProofVerifierInput csw, ProvingSystem provingSystem) const
+CScProof BlockchainTestManager::GenerateTestCswProof(CCswProofVerifierItem csw, ProvingSystem provingSystem) const
 {
     wrappedFieldPtr sptrScId = CFieldElement(csw.scId).GetFieldElement();
     field_t* scidFe = sptrScId.get();
@@ -750,12 +750,12 @@ void BlockchainTestManager::StoreSidechainWithCurrentHeight(const uint256& scId,
  * @return true If the certificate proof is correctly verified.
  * @return false If the certificate proof is not valid.
  */
-bool BlockchainTestManager::VerifyCertificateProof(CCertProofVerifierInput certificate) const
+bool BlockchainTestManager::VerifyCertificateProof(CCertProofVerifierItem certificate) const
 {
     wrappedFieldPtr   sptrConst  = certificate.constant.GetFieldElement();
     wrappedFieldPtr   sptrCum    = certificate.endEpochCumScTxCommTreeRoot.GetFieldElement();
-    wrappedScProofPtr sptrProof  = certificate.certProof.GetProofPtr();
-    wrappedScVkeyPtr  sptrCertVk = certificate.CertVk.GetVKeyPtr();
+    wrappedScProofPtr sptrProof  = certificate.proof.GetProofPtr();
+    wrappedScVkeyPtr  sptrCertVk = certificate.verificationKey.GetVKeyPtr();
 
     int customFieldsLen = certificate.vCustomFields.size(); 
 
@@ -810,7 +810,7 @@ bool BlockchainTestManager::VerifyCertificateProof(CCertProofVerifierInput certi
  * @return true If the CSW input proof is correctly verified.
  * @return false If the CSW input proof is not valid.
  */
-bool BlockchainTestManager::VerifyCswProof(CCswProofVerifierInput csw) const
+bool BlockchainTestManager::VerifyCswProof(CCswProofVerifierItem csw) const
 {
     wrappedFieldPtr sptrScId = CFieldElement(csw.scId).GetFieldElement();
     field_t* scidFe = sptrScId.get();
@@ -821,8 +821,8 @@ bool BlockchainTestManager::VerifyCswProof(CCswProofVerifierInput csw) const
     wrappedFieldPtr   sptrCdh        = csw.certDataHash.GetFieldElement();
     wrappedFieldPtr   sptrCum        = csw.ceasingCumScTxCommTree.GetFieldElement();
     wrappedFieldPtr   sptrNullifier  = csw.nullifier.GetFieldElement();
-    wrappedScProofPtr sptrProof      = csw.cswProof.GetProofPtr();
-    wrappedScVkeyPtr  sptrCeasedVk   = csw.ceasedVk.GetVKeyPtr();
+    wrappedScProofPtr sptrProof      = csw.proof.GetProofPtr();
+    wrappedScVkeyPtr  sptrCeasedVk   = csw.verificationKey.GetVKeyPtr();
 
     CctpErrorCode code;
 

--- a/src/gtest/tx_creation_utils.h
+++ b/src/gtest/tx_creation_utils.h
@@ -179,12 +179,12 @@ public:
     // SIDECHAIN HELPERS
     CScCertificate GenerateCertificate(uint256 scId, int epochNumber, int64_t quality, ProvingSystem provingSystem, CTransactionBase* inputTxBase = nullptr) const;
     void GenerateSidechainTestParameters(ProvingSystem provingSystem, TestCircuitType circuitType) const;
-    CScProof GenerateTestCertificateProof(CCertProofVerifierInput certificate, ProvingSystem provingSystem) const;
-    CScProof GenerateTestCswProof(CCswProofVerifierInput csw, ProvingSystem provingSystem) const;
+    CScProof GenerateTestCertificateProof(CCertProofVerifierItem certificate, ProvingSystem provingSystem) const;
+    CScProof GenerateTestCswProof(CCswProofVerifierItem csw, ProvingSystem provingSystem) const;
     CScVKey GetTestVerificationKey(ProvingSystem provingSystem, TestCircuitType circuitType) const;
     void StoreSidechainWithCurrentHeight(const uint256& scId, const CSidechain& sidechain, int chainActiveHeight) const;
-    bool VerifyCertificateProof(CCertProofVerifierInput certificate) const;
-    bool VerifyCswProof(CCswProofVerifierInput csw) const;
+    bool VerifyCertificateProof(CCertProofVerifierItem certificate) const;
+    bool VerifyCswProof(CCswProofVerifierItem csw) const;
 
     // ASYNC PROOF VERIFIER HELPERS
     size_t PendingAsyncCertProofs() const;

--- a/src/gtest/tx_creation_utils.h
+++ b/src/gtest/tx_creation_utils.h
@@ -179,12 +179,12 @@ public:
     // SIDECHAIN HELPERS
     CScCertificate GenerateCertificate(uint256 scId, int epochNumber, int64_t quality, ProvingSystem provingSystem, CTransactionBase* inputTxBase = nullptr) const;
     void GenerateSidechainTestParameters(ProvingSystem provingSystem, TestCircuitType circuitType) const;
-    CScProof GenerateTestCertificateProof(CCertProofVerifierItem certificate, ProvingSystem provingSystem) const;
-    CScProof GenerateTestCswProof(CCswProofVerifierItem csw, ProvingSystem provingSystem) const;
+    CScProof GenerateTestCertificateProof(CCertProofVerifierInput certificate, ProvingSystem provingSystem) const;
+    CScProof GenerateTestCswProof(CCswProofVerifierInput csw, ProvingSystem provingSystem) const;
     CScVKey GetTestVerificationKey(ProvingSystem provingSystem, TestCircuitType circuitType) const;
     void StoreSidechainWithCurrentHeight(const uint256& scId, const CSidechain& sidechain, int chainActiveHeight) const;
-    bool VerifyCertificateProof(CCertProofVerifierItem certificate) const;
-    bool VerifyCswProof(CCswProofVerifierItem csw) const;
+    bool VerifyCertificateProof(CCertProofVerifierInput certificate) const;
+    bool VerifyCswProof(CCswProofVerifierInput csw) const;
 
     // ASYNC PROOF VERIFIER HELPERS
     size_t PendingAsyncCertProofs() const;

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -315,7 +315,7 @@ CScCertificate::MakeShared() const {
 
 CFieldElement CScCertificate::GetDataHash(const Sidechain::ScFixedParameters& scFixedParams) const
 {
-    CCertProofVerifierInput input = SidechainProofVerifier::CertificateToVerifierInput(*this, scFixedParams, nullptr);
+    CCertProofVerifierInput input = CScProofVerifier::CertificateToVerifierInput(*this, scFixedParams, nullptr);
 
     int custom_fields_len = input.vCustomFields.size(); 
     std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -315,7 +315,7 @@ CScCertificate::MakeShared() const {
 
 CFieldElement CScCertificate::GetDataHash(const Sidechain::ScFixedParameters& scFixedParams) const
 {
-    CCertProofVerifierItem input = CScProofVerifier::CertificateToVerifierItem(*this, scFixedParams, nullptr);
+    CCertProofVerifierInput input = CScProofVerifier::CertificateToVerifierItem(*this, scFixedParams, nullptr);
 
     int custom_fields_len = input.vCustomFields.size(); 
     std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);

--- a/src/primitives/certificate.cpp
+++ b/src/primitives/certificate.cpp
@@ -315,7 +315,7 @@ CScCertificate::MakeShared() const {
 
 CFieldElement CScCertificate::GetDataHash(const Sidechain::ScFixedParameters& scFixedParams) const
 {
-    CCertProofVerifierInput input = CScProofVerifier::CertificateToVerifierInput(*this, scFixedParams, nullptr);
+    CCertProofVerifierItem input = CScProofVerifier::CertificateToVerifierItem(*this, scFixedParams, nullptr);
 
     int custom_fields_len = input.vCustomFields.size(); 
     std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);
@@ -340,8 +340,8 @@ CFieldElement CScCertificate::GetDataHash(const Sidechain::ScFixedParameters& sc
 
     wrappedFieldPtr   sptrConst  = input.constant.GetFieldElement();
     wrappedFieldPtr   sptrCum    = input.endEpochCumScTxCommTreeRoot.GetFieldElement();
-    wrappedScProofPtr sptrProof  = input.certProof.GetProofPtr();
-    wrappedScVkeyPtr  sptrCertVk = input.CertVk.GetVKeyPtr();
+    wrappedScProofPtr sptrProof  = input.proof.GetProofPtr();
+    wrappedScVkeyPtr  sptrCertVk = input.verificationKey.GetVKeyPtr();
 
     CctpErrorCode errorCode;
 

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -398,25 +398,4 @@ struct CScCertificateView
     }
 };
 
-/**
- * @brief A structure that includes all the arguments needed for verifying the proof of a certificate.
- */
-struct CCertProofVerifierInput
-{
-    uint64_t proofId;
-    std::shared_ptr<CScCertificate> certificatePtr;
-    uint256 certHash;
-    CFieldElement constant;
-    uint32_t epochNumber;
-    uint64_t quality;
-    std::vector<backward_transfer_t> bt_list;
-    std::vector<CFieldElement> vCustomFields;
-    CFieldElement endEpochCumScTxCommTreeRoot;
-    uint64_t mainchainBackwardTransferRequestScFee;
-    uint64_t forwardTransferScFee;
-    CScProof certProof;
-    CScVKey CertVk;
-    CNode* node;    /**< The node that sent the transaction. It can be null. */
-};
-
 #endif // _CERTIFICATE_H

--- a/src/primitives/certificate.h
+++ b/src/primitives/certificate.h
@@ -403,6 +403,7 @@ struct CScCertificateView
  */
 struct CCertProofVerifierInput
 {
+    uint64_t proofId;
     std::shared_ptr<CScCertificate> certificatePtr;
     uint256 certHash;
     CFieldElement constant;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1104,22 +1104,4 @@ struct CMutableTransaction : public CMutableTransactionBase
     bool add(const CFieldElement& acd);
 };
 
-/**
- * @brief A structure that includes all the arguments needed for verifying the proof of a CSW input.
- */
-struct CCswProofVerifierInput
-{
-    uint64_t proofId;
-    CScVKey ceasedVk;
-    CFieldElement ceasingCumScTxCommTree;
-    CFieldElement certDataHash;
-    CScProof cswProof;
-    CNode* node;    /**< The node that sent the transaction. */
-    CAmount nValue;
-    CFieldElement nullifier;
-    uint160 pubKeyHash;
-    uint256 scId;
-    std::shared_ptr<CTransaction> transactionPtr;
-};
-
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1109,6 +1109,7 @@ struct CMutableTransaction : public CMutableTransactionBase
  */
 struct CCswProofVerifierInput
 {
+    uint64_t proofId;
     CScVKey ceasedVk;
     CFieldElement ceasingCumScTxCommTree;
     CFieldElement certDataHash;

--- a/src/sc/asyncproofverifier.cpp
+++ b/src/sc/asyncproofverifier.cpp
@@ -104,11 +104,11 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
 
                 if (!batchResult.first)
                 {
-                    LogPrint("cert", "%s():%d - Batch verification failed, proceeding one by one... \n",
+                    LogPrint("cert", "%s():%d - Batch verification failed, removing proofs that caused the failure... \n",
                              __func__, __LINE__);
 
                     // If the batch verification fails, check the proofs one by one
-                    //outputs = NormalVerify(tempCswData, tempCertData);
+                    outputs = NormalVerify(tempCswData, tempCertData);
                 }
 
                 // Post processing of proofs
@@ -148,153 +148,149 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
     }
 }
 
-// /**
-//  * @brief Run the verification for CSW inputs and certificates one by one (not batched).
-//  * 
-//  * @param cswInputs The map of CSW inputs data to be verified.
-//  * @param certInputs The map of certificates data to be verified.
-//  * @return std::vector<AsyncProofVerifierOutput> The result of all processed proofs.
-//  */
-// std::vector<AsyncProofVerifierOutput> CScAsyncProofVerifier::NormalVerify(const std::map</*scTxHash*/uint256,
-//                                                                           std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
-//                                                                           const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const
-// {
-//     std::vector<AsyncProofVerifierOutput> outputs;
+/**
+ * @brief Run the verification for CSW inputs and certificates one by one (not batched).
+ * 
+ * @param cswInputs The map of CSW inputs data to be verified.
+ * @param certInputs The map of certificates data to be verified.
+ * @return std::vector<AsyncProofVerifierOutput> The result of all processed proofs.
+ */
+std::map<uint256, ProofVerifierOutput> CScAsyncProofVerifier::NormalVerify(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
+                                                                     const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs) const
+{
+    std::map<uint256, ProofVerifierOutput> outputs;
 
-//     for (const auto& verifierInput : cswInputs)
-//     {
-//         bool res = NormalVerifyCsw(verifierInput.first, verifierInput.second);
+    for (const auto& verifierInput : cswProofs)
+    {
+        ProofVerificationResult res = NormalVerifyCsw(verifierInput.second);
 
-//         outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.begin()->second.transactionPtr,
-//                                                     .node = verifierInput.second.begin()->second.node,
-//                                                     .proofVerified = res });
-//     }
+        outputs.insert(std::make_pair(verifierInput.first, ProofVerifierOutput{ .tx = verifierInput.second.begin()->parentPtr,
+                                                                                .node = verifierInput.second.begin()->node,
+                                                                                .proofResult = res }));
+    }
 
-//     for (const auto& verifierInput : certInputs)
-//     {
-//         bool res = NormalVerifyCertificate(verifierInput.second);
+    for (const auto& verifierInput : certProofs)
+    {
+        ProofVerificationResult res = NormalVerifyCertificate(*verifierInput.second.begin());
 
-//         outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.certificatePtr,
-//                                                     .node = verifierInput.second.node,
-//                                                     .proofVerified = res });
-//     }
+        outputs.insert(std::make_pair(verifierInput.first, ProofVerifierOutput{ .tx = verifierInput.second.begin()->parentPtr,
+                                                                                .node = verifierInput.second.begin()->node,
+                                                                                .proofResult = res }));
+    }
 
-//     return outputs;
-// }
+    return outputs;
+}
 
-// /**
-//  * @brief Run the normal verification for a certificate.
-//  * This is equivalent to running the batch verification with a single input.
-//  * 
-//  * @param input Data of the certificate to be verified.
-//  * @return true If the certificate proof is correctly verified
-//  * @return false If the certificate proof is rejected
-//  */
-// bool CScAsyncProofVerifier::NormalVerifyCertificate(CCertProofVerifierInput input) const
-// {
-//     CctpErrorCode code;
+/**
+ * @brief Run the normal verification for a certificate.
+ * This is equivalent to running the batch verification with a single input.
+ * 
+ * @param input Data of the certificate to be verified.
+ * @return true If the certificate proof is correctly verified
+ * @return false If the certificate proof is rejected
+ */
+ProofVerificationResult CScAsyncProofVerifier::NormalVerifyCertificate(CCertProofVerifierItem input) const
+{
+    CctpErrorCode code;
 
-//     int custom_fields_len = input.vCustomFields.size(); 
+    int custom_fields_len = input.vCustomFields.size(); 
 
-//     std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);
-//     int i = 0;
-//     std::vector<wrappedFieldPtr> vSptr;
-//     for (auto entry: input.vCustomFields)
-//     {
-//         wrappedFieldPtr sptrFe = entry.GetFieldElement();
-//         custom_fields[i] = sptrFe.get();
-//         vSptr.push_back(sptrFe);
-//         i++;
-//     }
+    std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);
+    int i = 0;
+    std::vector<wrappedFieldPtr> vSptr;
+    for (auto entry: input.vCustomFields)
+    {
+        wrappedFieldPtr sptrFe = entry.GetFieldElement();
+        custom_fields[i] = sptrFe.get();
+        vSptr.push_back(sptrFe);
+        i++;
+    }
 
-//     const backward_transfer_t* bt_list_ptr = input.bt_list.data();
-//     int bt_list_len = input.bt_list.size();
+    const backward_transfer_t* bt_list_ptr = input.bt_list.data();
+    int bt_list_len = input.bt_list.size();
 
-//     // mc crypto lib wants a null ptr if we have no elements
-//     if (custom_fields_len == 0)
-//         custom_fields.reset();
+    // mc crypto lib wants a null ptr if we have no elements
+    if (custom_fields_len == 0)
+        custom_fields.reset();
 
-//     if (bt_list_len == 0)
-//         bt_list_ptr = nullptr;
+    if (bt_list_len == 0)
+        bt_list_ptr = nullptr;
 
-//     wrappedFieldPtr   sptrConst  = input.constant.GetFieldElement();
-//     wrappedFieldPtr   sptrCum    = input.endEpochCumScTxCommTreeRoot.GetFieldElement();
-//     wrappedScProofPtr sptrProof  = input.certProof.GetProofPtr();
-//     wrappedScVkeyPtr  sptrCertVk = input.CertVk.GetVKeyPtr();
+    wrappedFieldPtr   sptrConst  = input.constant.GetFieldElement();
+    wrappedFieldPtr   sptrCum    = input.endEpochCumScTxCommTreeRoot.GetFieldElement();
+    wrappedScProofPtr sptrProof  = input.proof.GetProofPtr();
+    wrappedScVkeyPtr  sptrCertVk = input.verificationKey.GetVKeyPtr();
 
-//     bool ret = zendoo_verify_certificate_proof(
-//         sptrConst.get(),
-//         input.epochNumber,
-//         input.quality,
-//         bt_list_ptr,
-//         bt_list_len,
-//         custom_fields.get(),
-//         custom_fields_len,
-//         sptrCum.get(),
-//         input.mainchainBackwardTransferRequestScFee,
-//         input.forwardTransferScFee,
-//         sptrProof.get(),
-//         sptrCertVk.get(),
-//         &code
-//     );
+    bool ret = zendoo_verify_certificate_proof(
+        sptrConst.get(),
+        input.epochNumber,
+        input.quality,
+        bt_list_ptr,
+        bt_list_len,
+        custom_fields.get(),
+        custom_fields_len,
+        sptrCum.get(),
+        input.mainchainBackwardTransferRequestScFee,
+        input.forwardTransferScFee,
+        sptrProof.get(),
+        sptrCertVk.get(),
+        &code
+    );
 
-//     if (!ret || code != CctpErrorCode::OK)
-//     {
-//         LogPrintf("ERROR: %s():%d - cert [%s] has proof which does not verify: code [0x%x]\n",
-//             __func__, __LINE__, input.certHash.ToString(), code);
-//     }
+    if (!ret || code != CctpErrorCode::OK)
+    {
+        LogPrintf("ERROR: %s():%d - cert [%s] has proof which does not verify: code [0x%x]\n",
+            __func__, __LINE__, input.certHash.ToString(), code);
+    }
 
-//     return ret;
-// }
+    return ret ? ProofVerificationResult::Passed : ProofVerificationResult::Failed;
+}
 
-// /**
-//  * @brief Run the normal verification for the CSW inputs of a sidechain transaction.
-//  * This is equivalent to running the batch verification with a single input.
-//  * 
-//  * @param txHash The sidechain transaction hash.
-//  * @param inputMap The map of CSW input data to be verified.
-//  * @return true If the CSW proof is correctly verified
-//  * @return false If the CSW proof is rejected
-//  */
-// bool CScAsyncProofVerifier::NormalVerifyCsw(uint256 txHash, std::map</*outputPos*/unsigned int, CCswProofVerifierInput> inputMap) const
-// {
-//     for (const auto& entry : inputMap)
-//     {
-//         const CCswProofVerifierInput& input = entry.second;
-    
-//         wrappedFieldPtr sptrScId = CFieldElement(input.scId).GetFieldElement();
-//         field_t* scid_fe = sptrScId.get();
+/**
+ * @brief Run the normal verification for the CSW inputs of a sidechain transaction.
+ * This is equivalent to running the batch verification with a single input.
+ * 
+ * @param inputMap The map of CSW input data to be verified.
+ * @return true If the CSW proof is correctly verified
+ * @return false If the CSW proof is rejected
+ */
+ProofVerificationResult CScAsyncProofVerifier::NormalVerifyCsw(std::vector<CCswProofVerifierItem> cswInputs) const
+{
+    for (CCswProofVerifierItem input : cswInputs)
+    {
+        wrappedFieldPtr sptrScId = CFieldElement(input.scId).GetFieldElement();
+        field_t* scid_fe = sptrScId.get();
  
-//         const uint160& csw_pk_hash = input.pubKeyHash;
-//         BufferWithSize bws_csw_pk_hash(csw_pk_hash.begin(), csw_pk_hash.size());
+        const uint160& csw_pk_hash = input.pubKeyHash;
+        BufferWithSize bws_csw_pk_hash(csw_pk_hash.begin(), csw_pk_hash.size());
      
-//         wrappedFieldPtr   sptrCdh       = input.certDataHash.GetFieldElement();
-//         wrappedFieldPtr   sptrCum       = input.ceasingCumScTxCommTree.GetFieldElement();
-//         wrappedFieldPtr   sptrNullifier = input.nullifier.GetFieldElement();
-//         wrappedScProofPtr sptrProof     = input.cswProof.GetProofPtr();
-//         wrappedScVkeyPtr  sptrCeasedVk  = input.ceasedVk.GetVKeyPtr();
+        wrappedFieldPtr   sptrCdh       = input.certDataHash.GetFieldElement();
+        wrappedFieldPtr   sptrCum       = input.ceasingCumScTxCommTree.GetFieldElement();
+        wrappedFieldPtr   sptrNullifier = input.nullifier.GetFieldElement();
+        wrappedScProofPtr sptrProof     = input.proof.GetProofPtr();
+        wrappedScVkeyPtr  sptrCeasedVk  = input.verificationKey.GetVKeyPtr();
 
-//         CctpErrorCode code;
-//         bool ret = zendoo_verify_csw_proof(
-//                     input.nValue,
-//                     scid_fe, 
-//                     sptrNullifier.get(),
-//                     &bws_csw_pk_hash,
-//                     sptrCdh.get(),
-//                     sptrCum.get(),
-//                     sptrProof.get(),
-//                     sptrCeasedVk.get(),
-//                     &code);
+        CctpErrorCode code;
+        bool ret = zendoo_verify_csw_proof(
+                    input.nValue,
+                    scid_fe, 
+                    sptrNullifier.get(),
+                    &bws_csw_pk_hash,
+                    sptrCdh.get(),
+                    sptrCum.get(),
+                    sptrProof.get(),
+                    sptrCeasedVk.get(),
+                    &code);
 
-//         if (!ret || code != CctpErrorCode::OK)
-//         {
-//             LogPrintf("ERROR: %s():%d - tx [%s] has csw proof which does not verify: ret[%d], code [0x%x]\n",
-//                 __func__, __LINE__, input.transactionPtr->GetHash().ToString(), (int)ret, code);
-//             return false;
-//         }
-//     }
-//     return true;
-// }
+        if (!ret || code != CctpErrorCode::OK)
+        {
+            LogPrintf("ERROR: %s():%d - tx [%s] has csw proof which does not verify: ret[%d], code [0x%x]\n",
+                __func__, __LINE__, input.parentPtr->GetHash().ToString(), (int)ret, code);
+            return ProofVerificationResult::Failed;
+        }
+    }
+    return ProofVerificationResult::Passed;
+}
 
 /**
  * @brief Update the statistics of the proof verifier.

--- a/src/sc/asyncproofverifier.cpp
+++ b/src/sc/asyncproofverifier.cpp
@@ -153,7 +153,11 @@ void CScAsyncProofVerifier::ProcessVerificationOutputs(std::map</* Tx hash */ ui
     {
         CProofVerifierItem item = i->second;
 
-        if (item.result == ProofVerificationResult::Failed || item.result == ProofVerificationResult::Passed)
+        if (item.result == ProofVerificationResult::Unknown)
+        {
+            i++;
+        }
+        else
         {
             LogPrint("cert", "%s():%d - Post processing certificate or transaction [%s] from node [%d], result [%s] \n",
                     __func__, __LINE__, item.parentPtr->GetHash().ToString(), item.node->GetId(), ProofVerificationResultToString(item.result));
@@ -171,10 +175,6 @@ void CScAsyncProofVerifier::ProcessVerificationOutputs(std::map</* Tx hash */ ui
                                             dummyState);
 
             i = proofs.erase(i);
-        }
-        else
-        {
-            i++;
         }
     }
 }

--- a/src/sc/asyncproofverifier.cpp
+++ b/src/sc/asyncproofverifier.cpp
@@ -77,8 +77,8 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
             if (queueAge > batchVerificationMaxDelay || currentQueueSize > batchVerificationMaxSize)
             {
                 queueAge = 0;
-                std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> tempCswData;
-                std::map</*certHash*/uint256, CCertProofVerifierInput> tempCertData;
+                std::map</*scTxHash*/uint256, std::vector<CCswProofVerifierItem>> tempCswData;
+                std::map</*certHash*/uint256, std::vector<CCertProofVerifierItem>> tempCertData;
 
                 {
                     LOCK(cs_asyncQueue);
@@ -99,8 +99,8 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
                     assert(tempCertData.size() == certQueueSize);
                 }
 
-                std::pair<bool, std::vector<AsyncProofVerifierOutput>> batchResult = BatchVerify(tempCswData, tempCertData);
-                std::vector<AsyncProofVerifierOutput> outputs = batchResult.second;
+                std::pair<bool, std::map<uint256, ProofVerifierOutput>> batchResult = BatchVerifyInternal(tempCswData, tempCertData);
+                std::map<uint256, ProofVerifierOutput> outputs = batchResult.second;
 
                 if (!batchResult.first)
                 {
@@ -108,14 +108,20 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
                              __func__, __LINE__);
 
                     // If the batch verification fails, check the proofs one by one
-                    outputs = NormalVerify(tempCswData, tempCertData);
+                    //outputs = NormalVerify(tempCswData, tempCertData);
                 }
 
                 // Post processing of proofs
-                for (AsyncProofVerifierOutput output : outputs)
+                for (auto entry : outputs)
                 {
+                    ProofVerifierOutput output = entry.second;
+
+                    // At the very end of the batch verification (after any eventual retry) the result of each proof must be
+                    // FAILED or PASSED, UNKNOWN is not admitted.
+                    assert(output.proofResult == ProofVerificationResult::Failed || output.proofResult == ProofVerificationResult::Passed);
+
                     LogPrint("cert", "%s():%d - Post processing certificate or transaction [%s] from node [%d], result [%d] \n",
-                             __func__, __LINE__, output.tx->GetHash().ToString(), output.node->GetId(), output.proofVerified);
+                             __func__, __LINE__, output.tx->GetHash().ToString(), output.node->GetId(), output.proofResult);
 
                     // CODE USED FOR UNIT TEST ONLY [Start]
                     if (BOOST_UNLIKELY(Params().NetworkIDString() == "regtest"))
@@ -132,7 +138,7 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
 
                     CValidationState dummyState;
                     ProcessTxBaseAcceptToMemoryPool(*output.tx.get(), output.node,
-                                                    output.proofVerified ? BatchVerificationStateFlag::VERIFIED : BatchVerificationStateFlag::FAILED,
+                                                    output.proofResult == ProofVerificationResult::Passed ? BatchVerificationStateFlag::VERIFIED : BatchVerificationStateFlag::FAILED,
                                                     dummyState);
                 }
             }
@@ -142,317 +148,181 @@ void CScAsyncProofVerifier::RunPeriodicVerification()
     }
 }
 
-/**
- * @brief Run the batch verification for all the queued CSW outputs and certificates.
- * 
- * @param cswInputs The map of CSW inputs data to be verified.
- * @param certInputs The map of certificates data to be verified.
- * @return std::pair<bool, std::vector<AsyncProofVerifierOutput>> A pair containing the total result of the whole batch verification (bool) and the list of single results.
- */
-std::pair<bool, std::vector<AsyncProofVerifierOutput>> CScAsyncProofVerifier::BatchVerify(
-    const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
-    const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const
-{
-    bool allProofsVerified = true;
-    std::vector<AsyncProofVerifierOutput> outputs;
+// /**
+//  * @brief Run the verification for CSW inputs and certificates one by one (not batched).
+//  * 
+//  * @param cswInputs The map of CSW inputs data to be verified.
+//  * @param certInputs The map of certificates data to be verified.
+//  * @return std::vector<AsyncProofVerifierOutput> The result of all processed proofs.
+//  */
+// std::vector<AsyncProofVerifierOutput> CScAsyncProofVerifier::NormalVerify(const std::map</*scTxHash*/uint256,
+//                                                                           std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
+//                                                                           const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const
+// {
+//     std::vector<AsyncProofVerifierOutput> outputs;
 
-    CctpErrorCode code;
-    ZendooBatchProofVerifier batchVerifier;
-    bool ret = true;
+//     for (const auto& verifierInput : cswInputs)
+//     {
+//         bool res = NormalVerifyCsw(verifierInput.first, verifierInput.second);
 
-    for (const auto& verifierInput : cswInputs)
-    {
-        for (const auto& entry : verifierInput.second)
-        {
-            const CCswProofVerifierInput& input = entry.second;
+//         outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.begin()->second.transactionPtr,
+//                                                     .node = verifierInput.second.begin()->second.node,
+//                                                     .proofVerified = res });
+//     }
 
-            wrappedFieldPtr sptrScId = CFieldElement(input.scId).GetFieldElement();
-            field_t* scid_fe = sptrScId.get();
- 
-            const uint160& csw_pk_hash = input.pubKeyHash;
-            BufferWithSize bws_csw_pk_hash(csw_pk_hash.begin(), csw_pk_hash.size());
- 
-            wrappedFieldPtr   sptrCdh       = input.certDataHash.GetFieldElement();
-            wrappedFieldPtr   sptrCum       = input.ceasingCumScTxCommTree.GetFieldElement();
-            wrappedFieldPtr   sptrNullifier = input.nullifier.GetFieldElement();
-            wrappedScProofPtr sptrCswProof  = input.cswProof.GetProofPtr();
-            wrappedScVkeyPtr  sptrCeasedVk  = input.ceasedVk.GetVKeyPtr();
+//     for (const auto& verifierInput : certInputs)
+//     {
+//         bool res = NormalVerifyCertificate(verifierInput.second);
 
-            ret = batchVerifier.add_csw_proof(
-                input.proofId,
-                input.nValue,
-                scid_fe,
-                sptrNullifier.get(),
-                &bws_csw_pk_hash,
-                sptrCdh.get(),
-                sptrCum.get(),
-                sptrCswProof.get(),
-                sptrCeasedVk.get(),
-                &code
-            );
+//         outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.certificatePtr,
+//                                                     .node = verifierInput.second.node,
+//                                                     .proofVerified = res });
+//     }
 
-            if (!ret || code != CctpErrorCode::OK)
-            {
-                allProofsVerified = false;
- 
-                LogPrintf("ERROR: %s():%d - tx [%s] has csw proof which does not verify: ret[%d], code [0x%x]\n",
-                    __func__, __LINE__, input.transactionPtr->GetHash().ToString(), (int)ret, code);
-                // If one of csw tx inputs fail the whole tx must be marked as invalid. Break here. 
-                break;
-            }
-        }
-        outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.begin()->second.transactionPtr,
-                                                    .node = verifierInput.second.begin()->second.node,
-                                                    .proofVerified = ret });
-    }
+//     return outputs;
+// }
 
-    for (const auto& verifierInput : certInputs)
-    {
-        const CCertProofVerifierInput& input = verifierInput.second;
+// /**
+//  * @brief Run the normal verification for a certificate.
+//  * This is equivalent to running the batch verification with a single input.
+//  * 
+//  * @param input Data of the certificate to be verified.
+//  * @return true If the certificate proof is correctly verified
+//  * @return false If the certificate proof is rejected
+//  */
+// bool CScAsyncProofVerifier::NormalVerifyCertificate(CCertProofVerifierInput input) const
+// {
+//     CctpErrorCode code;
 
-        int custom_fields_len = input.vCustomFields.size(); 
-        std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);
-        int i = 0;
-        std::vector<wrappedFieldPtr> vSptr;
-        for (auto entry: input.vCustomFields)
-        {
-            wrappedFieldPtr sptrFe = entry.GetFieldElement();
-            custom_fields[i] = sptrFe.get();
-            vSptr.push_back(sptrFe);
-            i++;
-        }
+//     int custom_fields_len = input.vCustomFields.size(); 
 
-        const backward_transfer_t* bt_list_ptr = input.bt_list.data();
-        int bt_list_len = input.bt_list.size();
- 
-        // mc crypto lib wants a null ptr if we have no elements
-        if (custom_fields_len == 0)
-            custom_fields.reset();
- 
-        if (bt_list_len == 0)
-            bt_list_ptr = nullptr;
+//     std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);
+//     int i = 0;
+//     std::vector<wrappedFieldPtr> vSptr;
+//     for (auto entry: input.vCustomFields)
+//     {
+//         wrappedFieldPtr sptrFe = entry.GetFieldElement();
+//         custom_fields[i] = sptrFe.get();
+//         vSptr.push_back(sptrFe);
+//         i++;
+//     }
 
-        wrappedFieldPtr   sptrConst  = input.constant.GetFieldElement();
-        wrappedFieldPtr   sptrCum    = input.endEpochCumScTxCommTreeRoot.GetFieldElement();
-        wrappedScProofPtr sptrProof  = input.certProof.GetProofPtr();
-        wrappedScVkeyPtr  sptrCertVk = input.CertVk.GetVKeyPtr();
+//     const backward_transfer_t* bt_list_ptr = input.bt_list.data();
+//     int bt_list_len = input.bt_list.size();
 
-        bool ret = batchVerifier.add_certificate_proof(
-            input.proofId,
-            sptrConst.get(),
-            input.epochNumber,
-            input.quality,
-            bt_list_ptr,
-            bt_list_len,
-            custom_fields.get(),
-            custom_fields_len,
-            sptrCum.get(),
-            input.mainchainBackwardTransferRequestScFee,
-            input.forwardTransferScFee,
-            sptrProof.get(),
-            sptrCertVk.get(),
-            &code
-        );
+//     // mc crypto lib wants a null ptr if we have no elements
+//     if (custom_fields_len == 0)
+//         custom_fields.reset();
 
-        if (!ret || code != CctpErrorCode::OK)
-        {
-            allProofsVerified = false;
- 
-            LogPrintf("ERROR: %s():%d - cert [%s] has proof which does not verify: ret[%d], code [0x%x]\n",
-                __func__, __LINE__, input.certHash.ToString(), (int)ret, code);
-        }
-        outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.certificatePtr,
-                                                    .node = verifierInput.second.node,
-                                                    .proofVerified = ret });
-    }
+//     if (bt_list_len == 0)
+//         bt_list_ptr = nullptr;
 
-    CZendooBatchProofVerifierResult verRes(batchVerifier.batch_verify_all(&code));
-    if (!verRes.Result())
-    {
-        allProofsVerified = false;
- 
-        LogPrintf("ERROR: %s():%d - verify failed for %d proof(s), code [0x%x]\n",
-            __func__, __LINE__, verRes.FailedProofs().size(), code);
-    }
+//     wrappedFieldPtr   sptrConst  = input.constant.GetFieldElement();
+//     wrappedFieldPtr   sptrCum    = input.endEpochCumScTxCommTreeRoot.GetFieldElement();
+//     wrappedScProofPtr sptrProof  = input.certProof.GetProofPtr();
+//     wrappedScVkeyPtr  sptrCertVk = input.CertVk.GetVKeyPtr();
 
-    return std::pair<bool, std::vector<AsyncProofVerifierOutput>> { allProofsVerified, outputs };
-}
+//     bool ret = zendoo_verify_certificate_proof(
+//         sptrConst.get(),
+//         input.epochNumber,
+//         input.quality,
+//         bt_list_ptr,
+//         bt_list_len,
+//         custom_fields.get(),
+//         custom_fields_len,
+//         sptrCum.get(),
+//         input.mainchainBackwardTransferRequestScFee,
+//         input.forwardTransferScFee,
+//         sptrProof.get(),
+//         sptrCertVk.get(),
+//         &code
+//     );
 
-/**
- * @brief Run the verification for CSW inputs and certificates one by one (not batched).
- * 
- * @param cswInputs The map of CSW inputs data to be verified.
- * @param certInputs The map of certificates data to be verified.
- * @return std::vector<AsyncProofVerifierOutput> The result of all processed proofs.
- */
-std::vector<AsyncProofVerifierOutput> CScAsyncProofVerifier::NormalVerify(const std::map</*scTxHash*/uint256,
-                                                                          std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
-                                                                          const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const
-{
-    std::vector<AsyncProofVerifierOutput> outputs;
+//     if (!ret || code != CctpErrorCode::OK)
+//     {
+//         LogPrintf("ERROR: %s():%d - cert [%s] has proof which does not verify: code [0x%x]\n",
+//             __func__, __LINE__, input.certHash.ToString(), code);
+//     }
 
-    for (const auto& verifierInput : cswInputs)
-    {
-        bool res = NormalVerifyCsw(verifierInput.first, verifierInput.second);
+//     return ret;
+// }
 
-        outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.begin()->second.transactionPtr,
-                                                    .node = verifierInput.second.begin()->second.node,
-                                                    .proofVerified = res });
-    }
-
-    for (const auto& verifierInput : certInputs)
-    {
-        bool res = NormalVerifyCertificate(verifierInput.second);
-
-        outputs.push_back(AsyncProofVerifierOutput{ .tx = verifierInput.second.certificatePtr,
-                                                    .node = verifierInput.second.node,
-                                                    .proofVerified = res });
-    }
-
-    return outputs;
-}
-
-/**
- * @brief Run the normal verification for a certificate.
- * This is equivalent to running the batch verification with a single input.
- * 
- * @param input Data of the certificate to be verified.
- * @return true If the certificate proof is correctly verified
- * @return false If the certificate proof is rejected
- */
-bool CScAsyncProofVerifier::NormalVerifyCertificate(CCertProofVerifierInput input) const
-{
-    CctpErrorCode code;
-
-    int custom_fields_len = input.vCustomFields.size(); 
-
-    std::unique_ptr<const field_t*[]> custom_fields(new const field_t*[custom_fields_len]);
-    int i = 0;
-    std::vector<wrappedFieldPtr> vSptr;
-    for (auto entry: input.vCustomFields)
-    {
-        wrappedFieldPtr sptrFe = entry.GetFieldElement();
-        custom_fields[i] = sptrFe.get();
-        vSptr.push_back(sptrFe);
-        i++;
-    }
-
-    const backward_transfer_t* bt_list_ptr = input.bt_list.data();
-    int bt_list_len = input.bt_list.size();
-
-    // mc crypto lib wants a null ptr if we have no elements
-    if (custom_fields_len == 0)
-        custom_fields.reset();
-
-    if (bt_list_len == 0)
-        bt_list_ptr = nullptr;
-
-    wrappedFieldPtr   sptrConst  = input.constant.GetFieldElement();
-    wrappedFieldPtr   sptrCum    = input.endEpochCumScTxCommTreeRoot.GetFieldElement();
-    wrappedScProofPtr sptrProof  = input.certProof.GetProofPtr();
-    wrappedScVkeyPtr  sptrCertVk = input.CertVk.GetVKeyPtr();
-
-    bool ret = zendoo_verify_certificate_proof(
-        sptrConst.get(),
-        input.epochNumber,
-        input.quality,
-        bt_list_ptr,
-        bt_list_len,
-        custom_fields.get(),
-        custom_fields_len,
-        sptrCum.get(),
-        input.mainchainBackwardTransferRequestScFee,
-        input.forwardTransferScFee,
-        sptrProof.get(),
-        sptrCertVk.get(),
-        &code
-    );
-
-    if (!ret || code != CctpErrorCode::OK)
-    {
-        LogPrintf("ERROR: %s():%d - cert [%s] has proof which does not verify: code [0x%x]\n",
-            __func__, __LINE__, input.certHash.ToString(), code);
-    }
-
-    return ret;
-}
-
-/**
- * @brief Run the normal verification for the CSW inputs of a sidechain transaction.
- * This is equivalent to running the batch verification with a single input.
- * 
- * @param txHash The sidechain transaction hash.
- * @param inputMap The map of CSW input data to be verified.
- * @return true If the CSW proof is correctly verified
- * @return false If the CSW proof is rejected
- */
-bool CScAsyncProofVerifier::NormalVerifyCsw(uint256 txHash, std::map</*outputPos*/unsigned int, CCswProofVerifierInput> inputMap) const
-{
-    for (const auto& entry : inputMap)
-    {
-        const CCswProofVerifierInput& input = entry.second;
+// /**
+//  * @brief Run the normal verification for the CSW inputs of a sidechain transaction.
+//  * This is equivalent to running the batch verification with a single input.
+//  * 
+//  * @param txHash The sidechain transaction hash.
+//  * @param inputMap The map of CSW input data to be verified.
+//  * @return true If the CSW proof is correctly verified
+//  * @return false If the CSW proof is rejected
+//  */
+// bool CScAsyncProofVerifier::NormalVerifyCsw(uint256 txHash, std::map</*outputPos*/unsigned int, CCswProofVerifierInput> inputMap) const
+// {
+//     for (const auto& entry : inputMap)
+//     {
+//         const CCswProofVerifierInput& input = entry.second;
     
-        wrappedFieldPtr sptrScId = CFieldElement(input.scId).GetFieldElement();
-        field_t* scid_fe = sptrScId.get();
+//         wrappedFieldPtr sptrScId = CFieldElement(input.scId).GetFieldElement();
+//         field_t* scid_fe = sptrScId.get();
  
-        const uint160& csw_pk_hash = input.pubKeyHash;
-        BufferWithSize bws_csw_pk_hash(csw_pk_hash.begin(), csw_pk_hash.size());
+//         const uint160& csw_pk_hash = input.pubKeyHash;
+//         BufferWithSize bws_csw_pk_hash(csw_pk_hash.begin(), csw_pk_hash.size());
      
-        wrappedFieldPtr   sptrCdh       = input.certDataHash.GetFieldElement();
-        wrappedFieldPtr   sptrCum       = input.ceasingCumScTxCommTree.GetFieldElement();
-        wrappedFieldPtr   sptrNullifier = input.nullifier.GetFieldElement();
-        wrappedScProofPtr sptrProof     = input.cswProof.GetProofPtr();
-        wrappedScVkeyPtr  sptrCeasedVk  = input.ceasedVk.GetVKeyPtr();
+//         wrappedFieldPtr   sptrCdh       = input.certDataHash.GetFieldElement();
+//         wrappedFieldPtr   sptrCum       = input.ceasingCumScTxCommTree.GetFieldElement();
+//         wrappedFieldPtr   sptrNullifier = input.nullifier.GetFieldElement();
+//         wrappedScProofPtr sptrProof     = input.cswProof.GetProofPtr();
+//         wrappedScVkeyPtr  sptrCeasedVk  = input.ceasedVk.GetVKeyPtr();
 
-        CctpErrorCode code;
-        bool ret = zendoo_verify_csw_proof(
-                    input.nValue,
-                    scid_fe, 
-                    sptrNullifier.get(),
-                    &bws_csw_pk_hash,
-                    sptrCdh.get(),
-                    sptrCum.get(),
-                    sptrProof.get(),
-                    sptrCeasedVk.get(),
-                    &code);
+//         CctpErrorCode code;
+//         bool ret = zendoo_verify_csw_proof(
+//                     input.nValue,
+//                     scid_fe, 
+//                     sptrNullifier.get(),
+//                     &bws_csw_pk_hash,
+//                     sptrCdh.get(),
+//                     sptrCum.get(),
+//                     sptrProof.get(),
+//                     sptrCeasedVk.get(),
+//                     &code);
 
-        if (!ret || code != CctpErrorCode::OK)
-        {
-            LogPrintf("ERROR: %s():%d - tx [%s] has csw proof which does not verify: ret[%d], code [0x%x]\n",
-                __func__, __LINE__, input.transactionPtr->GetHash().ToString(), (int)ret, code);
-            return false;
-        }
-    }
-    return true;
-}
+//         if (!ret || code != CctpErrorCode::OK)
+//         {
+//             LogPrintf("ERROR: %s():%d - tx [%s] has csw proof which does not verify: ret[%d], code [0x%x]\n",
+//                 __func__, __LINE__, input.transactionPtr->GetHash().ToString(), (int)ret, code);
+//             return false;
+//         }
+//     }
+//     return true;
+// }
 
 /**
  * @brief Update the statistics of the proof verifier.
  * It must be used in regression test mode only.
  * @param output The result of the proof verification that has been performed.
  */
-void CScAsyncProofVerifier::UpdateStatistics(const AsyncProofVerifierOutput& output)
+void CScAsyncProofVerifier::UpdateStatistics(const ProofVerifierOutput& output)
 {
     assert(Params().NetworkIDString() == "regtest");
 
     if (output.tx->IsCertificate())
     {
-        if (output.proofVerified)
+        if (output.proofResult == ProofVerificationResult::Passed)
         {
             stats.okCertCounter++;
         }
-        else
+        else if (output.proofResult == ProofVerificationResult::Failed)
         {
             stats.failedCertCounter++;
         }
     }
     else
     {
-        if (output.proofVerified)
+        if (output.proofResult == ProofVerificationResult::Passed)
         {
             stats.okCswCounter++;
         }
-        else
+        else if (output.proofResult == ProofVerificationResult::Failed)
         {
             stats.failedCswCounter++;
         }

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -130,7 +130,7 @@ public:
 
         for (auto item : CScAsyncProofVerifier::GetInstance().proofQueue)
         {
-            if (item.second.certInput)
+            if (item.second.proofInput.type() == typeid(CCertProofVerifierInput))
             {
                 counter++;
             }
@@ -153,7 +153,7 @@ public:
 
         for (auto item : CScAsyncProofVerifier::GetInstance().proofQueue)
         {
-            if (item.second.cswInputs)
+            if (item.second.proofInput.type() == typeid(std::vector<CCswProofVerifierInput>))
             {
                 counter++;
             }

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -76,11 +76,10 @@ private:
     {
     }
 
-    // std::vector<AsyncProofVerifierOutput> NormalVerify(const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int,
-    //                                                    CCswProofVerifierInput>>& cswInputs,
-    //                                                    const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
-    // bool NormalVerifyCertificate(CCertProofVerifierInput input) const;
-    // bool NormalVerifyCsw(uint256 txHash, std::map</*outputPos*/unsigned int, CCswProofVerifierInput> inputMap) const;
+    std::map<uint256, ProofVerifierOutput> NormalVerify(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
+                                                        const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs) const;
+    ProofVerificationResult NormalVerifyCertificate(CCertProofVerifierItem input) const;
+    ProofVerificationResult NormalVerifyCsw(std::vector<CCswProofVerifierItem> cswInputs) const;
 
     void UpdateStatistics(const ProofVerifierOutput& output);
 };

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -76,11 +76,9 @@ private:
     {
     }
 
-    std::map<uint256, ProofVerifierOutput> NormalVerify(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
-                                                        const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs) const;
-    ProofVerificationResult NormalVerifyCertificate(CCertProofVerifierItem input) const;
-    ProofVerificationResult NormalVerifyCsw(std::vector<CCswProofVerifierItem> cswInputs) const;
-
+    void ProcessVerificationOutputs(const std::map<uint256, ProofVerifierOutput> outputs,
+                                    std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
+                                    std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs);
     void UpdateStatistics(const ProofVerifierOutput& output);
 };
 

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -18,17 +18,6 @@ class uint256;
 class CCoinsViewCache;
 
 /**
- * @brief A structure containing the output data of a proof verification.
- */
-struct AsyncProofVerifierOutput
-{
-    std::shared_ptr<CTransactionBase> tx;    /**< The transaction which the proof verification refers to. */
-    CNode* node;                             /**< The node that sent the transaction. */
-    bool proofVerified;                      /**< True if the proof has been correctly verified, false otherwise. */
-    uint64_t proofId;                        /**< The unique identifier of the proof (used internally by the batch verifier). */
-};
-
-/**
  * @brief A structure storing statistics about the async batch verifier process.
  * 
  */
@@ -87,20 +76,13 @@ private:
     {
     }
 
-    std::pair<bool, std::vector<AsyncProofVerifierOutput>> BatchVerify(const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int,
-                                                                        CCswProofVerifierInput>>& cswInputs,
-                                                                        const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
-    std::vector<AsyncProofVerifierOutput> NormalVerify(const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int,
-                                                       CCswProofVerifierInput>>& cswInputs,
-                                                       const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
-    bool NormalVerifyCertificate(CCertProofVerifierInput input) const;
-    bool NormalVerifyCsw(uint256 txHash, std::map</*outputPos*/unsigned int, CCswProofVerifierInput> inputMap) const;
+    // std::vector<AsyncProofVerifierOutput> NormalVerify(const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int,
+    //                                                    CCswProofVerifierInput>>& cswInputs,
+    //                                                    const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
+    // bool NormalVerifyCertificate(CCertProofVerifierInput input) const;
+    // bool NormalVerifyCsw(uint256 txHash, std::map</*outputPos*/unsigned int, CCswProofVerifierInput> inputMap) const;
 
-    void UpdateStatistics(const AsyncProofVerifierOutput& output);
-
-    std::pair<bool, std::vector<AsyncProofVerifierOutput>> _batchVerifyInternal(const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
-                                                                                 const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
-
+    void UpdateStatistics(const ProofVerifierOutput& output);
 };
 
 /**

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -24,6 +24,7 @@ struct AsyncProofVerifierOutput
     std::shared_ptr<CTransactionBase> tx;    /**< The transaction which the proof verification refers to. */
     CNode* node;                             /**< The node that sent the transaction. */
     bool proofVerified;                      /**< True if the proof has been correctly verified, false otherwise. */
+    uint64_t proofId;                        /**< The unique identifier of the proof (used internally by the batch verifier). */
 };
 
 /**

--- a/src/sc/asyncproofverifier.h
+++ b/src/sc/asyncproofverifier.h
@@ -77,8 +77,7 @@ private:
     }
 
     void ProcessVerificationOutputs(const std::map<uint256, ProofVerifierOutput> outputs,
-                                    std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
-                                    std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs);
+                                    std::map</* Tx hash */ uint256, CProofVerifierItem>& proofs);
     void UpdateStatistics(const ProofVerifierOutput& output);
 };
 
@@ -119,7 +118,17 @@ public:
      */
     size_t PendingAsyncCertProofs()
     {
-        return CScAsyncProofVerifier::GetInstance().certEnqueuedData.size();
+        int counter = 0;
+
+        for (auto item : CScAsyncProofVerifier::GetInstance().proofQueue)
+        {
+            if (item.second.certInput)
+            {
+                counter++;
+            }
+        }
+
+        return counter;
     }
 
     /**
@@ -130,7 +139,17 @@ public:
      */
     size_t PendingAsyncCswProofs()
     {
-        return CScAsyncProofVerifier::GetInstance().cswEnqueuedData.size();
+        int counter = 0;
+
+        for (auto item : CScAsyncProofVerifier::GetInstance().proofQueue)
+        {
+            if (item.second.cswInputs)
+            {
+                counter++;
+            }
+        }
+
+        return counter;
     }
 
     /**
@@ -150,8 +169,7 @@ public:
     {
         CScAsyncProofVerifier& verifier = CScAsyncProofVerifier::GetInstance();
 
-        verifier.certEnqueuedData.clear();
-        verifier.cswEnqueuedData.clear();
+        verifier.proofQueue.clear();
         verifier.stats = AsyncProofVerifierStatistics();
     }
 

--- a/src/sc/proofverifier.cpp
+++ b/src/sc/proofverifier.cpp
@@ -145,8 +145,6 @@ void CScProofVerifier::LoadDataForCertVerification(const CCoinsViewCache& view, 
     item.result = ProofVerificationResult::Unknown;
     item.certInput = CertificateToVerifierItem(scCert, sidechain.fixedParams, pfrom);
     assert(!item.cswInputs.is_initialized());
-    assert(item.cswInputs == boost::none);
-    assert(!item.cswInputs);
     proofQueue.insert(std::make_pair(scCert.GetHash(), item));
 }
 
@@ -183,8 +181,6 @@ void CScProofVerifier::LoadDataForCswVerification(const CCoinsViewCache& view, c
         item.node = pfrom;
         item.cswInputs = cswInputProofs;
         assert(!item.certInput.is_initialized());
-        assert(item.certInput == boost::none);
-        assert(!item.certInput);
         auto pair_ret = proofQueue.insert(std::make_pair(scTx.GetHash(), item));
 
         if (!pair_ret.second)
@@ -222,6 +218,11 @@ bool CScProofVerifier::BatchVerify()
  */
 bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs)
 {
+    if (proofs.size() == 0)
+    {
+        return true;
+    }
+
     if (verificationMode == Verification::Loose)
     {
         for (auto& proof : proofs)
@@ -229,11 +230,6 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
             proof.second.result = ProofVerificationResult::Passed;
             return true;
         }
-    }
-
-    if (proofs.size() == 0)
-    {
-        return true;
     }
 
     CctpErrorCode code;
@@ -393,7 +389,7 @@ bool CScProofVerifier::BatchVerifyInternal(std::map</* Cert or Tx hash */ uint25
         else
         {
             // We don't know which proofs made the batch process fail.
-            LogPrintf("ERROR: %s():%d - verify failed without detailed information\n", __func__, __LINE__);
+            LogPrintf("ERROR: %s():%d - verify failed without detailed information, code [0x%x]\n", __func__, __LINE__, code);
         }
     }
 

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -100,7 +100,7 @@ public:
     verificationMode(mode)
     {
     }
-    ~CScProofVerifier() = default;
+    virtual ~CScProofVerifier() = default;
 
     // CScProofVerifier should never be copied
     CScProofVerifier(const CScProofVerifier&) = delete;

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -14,41 +14,51 @@ class CScCertificate;
 class uint256;
 class CCoinsViewCache;
 
-/* Class for instantiating a verifier able to verify different kind of ScProof for different kind of ScProof(s) */
+/* Class for instantiating a verifier that is able to verify different kind of ScProof for different kind of ScProof(s) */
 class CScProofVerifier
 {
 public:
 
+    /**
+     * @brief The types of verification that can be requested the the proof verifier.
+     */
     enum class Verification
     {
-        Strict,
-        Loose
+        Strict,     /**< Perform normal verification. */
+        Loose       /**< Skip verification. */
     };
-    const Verification verificationMode;
 
-    CScProofVerifier(Verification mode): verificationMode(mode) {}
+    static CCertProofVerifierInput CertificateToVerifierInput(const CScCertificate& certificate, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
+    static CCswProofVerifierInput CswInputToVerifierInput(const CTxCeasedSidechainWithdrawalInput& cswInput, const CTransaction* cswTransaction, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
+
+    CScProofVerifier(Verification mode) :
+    verificationMode(mode)
+    {
+    }
     ~CScProofVerifier() = default;
 
     // CScProofVerifier should never be copied
     CScProofVerifier(const CScProofVerifier&) = delete;
     CScProofVerifier& operator=(const CScProofVerifier&) = delete;
 
-    void LoadDataForCertVerification(const CCoinsViewCache& view, const CScCertificate& scCert);
+    virtual void LoadDataForCertVerification(const CCoinsViewCache& view, const CScCertificate& scCert, CNode* pfrom = nullptr);
 
-    void LoadDataForCswVerification(const CCoinsViewCache& view, const CTransaction& scTx);
+    virtual void LoadDataForCswVerification(const CCoinsViewCache& view, const CTransaction& scTx, CNode* pfrom = nullptr);
     bool BatchVerify() const;
 
-private:
-    
-    // these would be useful once batch verification will be implemented
-    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> cswEnqueuedData;
-    std::map</*certHash*/uint256, CCertProofVerifierInput> certEnqueuedData;
-};
+protected:
+    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> cswEnqueuedData; /**< The queue of CSW proofs to be verified. */
+    std::map</*certHash*/uint256, CCertProofVerifierInput> certEnqueuedData;    /**< The queue of certificate proofs to be verified. */
 
-namespace SidechainProofVerifier
-{
-CCertProofVerifierInput CertificateToVerifierInput(const CScCertificate& certificate, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
-CCswProofVerifierInput CswInputToVerifierInput(const CTxCeasedSidechainWithdrawalInput& cswInput, const CTransaction* cswTransaction, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
-}
+private:
+
+    static std::atomic<uint32_t> proofIdCounter;   /**< The counter used to get a unique ID for proofs. */
+
+    const Verification verificationMode;    /**< The type of verification to be performed by this instance of proof verifier. */
+
+    std::pair<bool, std::vector<uint32_t>> BatchVerifyInternal(
+                                            const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
+                                            const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
+};
 
 #endif // _SC_PROOF_VERIFIER_H

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -3,11 +3,12 @@
 
 #include <map>
 
-#include <sc/sidechaintypes.h>
-#include <amount.h>
 #include <boost/variant.hpp>
-#include <primitives/certificate.h>
-#include <primitives/transaction.h>
+
+#include "amount.h"
+#include "primitives/certificate.h"
+#include "primitives/transaction.h"
+#include "sc/sidechaintypes.h"
 
 class CSidechain;
 class CScCertificate;
@@ -17,21 +18,23 @@ class CCoinsViewCache;
 /**
  * The enumeration of possible results of the proof verifier for any proof processed.
  */
-enum ProofVerificationResult
+enum class ProofVerificationResult
 {
     Unknown,    /**< The result of the batch verification is unknown. */
     Failed,     /**< The proof verification failed. */
     Passed      /**< The proof verification passed. */
 };
 
+std::string ProofVerificationResultToString(ProofVerificationResult res);
+
+/**
+ * @brief A base structure for generic inputs of the proof verifier.
+ */
 struct CBaseProofVerifierInput
 {
     uint32_t proofId;                               /**< A unique number identifying the proof. */
-    std::shared_ptr<CTransactionBase> parentPtr;    /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
-    CNode* node;                                    /**< The node that sent the parent (Transaction or Certiticate). */
     CScProof proof;                                 /**< The proof to be verified. */
     CScVKey verificationKey;                        /**< The key to be used for the verification. */
-    ProofVerificationResult result;                 /**< The result of the verification provess. */
 };
 
 /**
@@ -64,39 +67,25 @@ struct CCertProofVerifierInput : CBaseProofVerifierInput
 };
 
 /**
- * @brief The base struct for items added to the queue of the proof verifier.
+ * @brief The base structure for items added to the queue of the proof verifier.
  */
 struct CProofVerifierItem
 {
-    uint256 txHash;
-    std::shared_ptr<CTransactionBase> parentPtr;    /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
-    CNode* node;                                    /**< The node that sent the parent (Transaction or Certiticate). */
-    ProofVerificationResult result;
-    boost::optional<CCertProofVerifierInput> certInput;
-    boost::optional<std::vector<CCswProofVerifierInput>> cswInputs;
+    uint256 txHash;                                                     /**< The hash of the transaction/certificate whose proof(s) have to be verified. */
+    std::shared_ptr<CTransactionBase> parentPtr;                        /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
+    CNode* node;                                                        /**< The node that sent the parent (Transaction or Certiticate). */
+    ProofVerificationResult result;                                     /**< The overall result of the proof(s) verification for the transaction/certificate. */
+    boost::optional<CCertProofVerifierInput> certInput;                 /**< Certificate data to provide the proof verifier with. */
+    boost::optional<std::vector<CCswProofVerifierInput>> cswInputs;     /**< CSW outputs data to provide the proof verifier with. */
 };
 
-/**
- * @brief A structure containing the output data of a proof verification.
- */
-// struct ProofVerifierOutput
-// {
-//     std::shared_ptr<CTransactionBase> tx;    /**< The transaction which the proof verification refers to. */
-//     CNode* node;                             /**< The node that sent the transaction. */
-//     ProofVerificationResult proofResult;     /**< The result of the proof verification. */
-// };
-
-// typedef std::shared_ptr<CBaseProofVerifierItem> CBaseProofVerifierItemPtr;
-// typedef std::shared_ptr<CCertProofVerifierInput> CCertProofVerifierInputPtr;
-// typedef std::shared_ptr<CCswProofVerifierInput>  CCswProofVerifierInputPtr;
-
-/* Class for instantiating a verifier that is able to verify different kind of ScProof for different kind of ScProof(s) */
+/* A verifier that is able to verify different kind of ScProof(s) */
 class CScProofVerifier
 {
 public:
 
     /**
-     * @brief The types of verification that can be requested the the proof verifier.
+     * @brief The types of verification that can be requested to the proof verifier.
      */
     enum class Verification
     {
@@ -123,24 +112,19 @@ public:
     bool BatchVerify();
 
 protected:
-    //std::map</*scTxHash*/uint256, std::vector<CCswProofVerifierInput>> cswEnqueuedData;      /**< The queue of CSW proofs to be verified. */
-    //std::map</*certHash*/uint256, std::vector<CCertProofVerifierInput>> certEnqueuedData;    /**< The queue of certificate proofs to be verified. */
-    std::map</* Cert or Tx hash */ uint256, CProofVerifierItem> proofQueue;   /** The queue of proofs to be verified. */
 
     bool BatchVerifyInternal(std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs);
-
     void NormalVerify(std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs);
     ProofVerificationResult NormalVerifyCertificate(CCertProofVerifierInput input) const;
     ProofVerificationResult NormalVerifyCsw(std::vector<CCswProofVerifierInput> cswInputs) const;
+
+    std::map</* Cert or Tx hash */ uint256, CProofVerifierItem> proofQueue;   /**< The queue of proofs to be verified. */
 
 private:
 
     static std::atomic<uint32_t> proofIdCounter;   /**< The counter used to get a unique ID for proofs. */
 
     const Verification verificationMode;    /**< The type of verification to be performed by this instance of proof verifier. */
-
-    //std::map<uint256, ProofVerifierOutput> GenerateVerifierResults(const std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs,
-    //                                                               ProofVerificationResult defaultResult) const;
 };
 
 #endif // _SC_PROOF_VERIFIER_H

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -71,12 +71,11 @@ struct CCertProofVerifierInput : CBaseProofVerifierInput
  */
 struct CProofVerifierItem
 {
-    uint256 txHash;                                                     /**< The hash of the transaction/certificate whose proof(s) have to be verified. */
-    std::shared_ptr<CTransactionBase> parentPtr;                        /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
-    CNode* node;                                                        /**< The node that sent the parent (Transaction or Certiticate). */
-    ProofVerificationResult result;                                     /**< The overall result of the proof(s) verification for the transaction/certificate. */
-    boost::optional<CCertProofVerifierInput> certInput;                 /**< Certificate data to provide the proof verifier with. */
-    boost::optional<std::vector<CCswProofVerifierInput>> cswInputs;     /**< CSW outputs data to provide the proof verifier with. */
+    uint256 txHash;                                                                                 /**< The hash of the transaction/certificate whose proof(s) have to be verified. */
+    std::shared_ptr<CTransactionBase> parentPtr;                                                    /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
+    CNode* node;                                                                                    /**< The node that sent the parent (Transaction or Certiticate). */
+    ProofVerificationResult result;                                                                 /**< The overall result of the proof(s) verification for the transaction/certificate. */
+    boost::variant<CCertProofVerifierInput, std::vector<CCswProofVerifierInput>> proofInput;        /**< The proof input data, it can be a (single) certificate input or a list of CSW inputs. */
 };
 
 /* A verifier that is able to verify different kind of ScProof(s) */

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -79,12 +79,12 @@ struct CProofVerifierItem
 /**
  * @brief A structure containing the output data of a proof verification.
  */
-struct ProofVerifierOutput
-{
-    std::shared_ptr<CTransactionBase> tx;    /**< The transaction which the proof verification refers to. */
-    CNode* node;                             /**< The node that sent the transaction. */
-    ProofVerificationResult proofResult;     /**< The result of the proof verification. */
-};
+// struct ProofVerifierOutput
+// {
+//     std::shared_ptr<CTransactionBase> tx;    /**< The transaction which the proof verification refers to. */
+//     CNode* node;                             /**< The node that sent the transaction. */
+//     ProofVerificationResult proofResult;     /**< The result of the proof verification. */
+// };
 
 // typedef std::shared_ptr<CBaseProofVerifierItem> CBaseProofVerifierItemPtr;
 // typedef std::shared_ptr<CCertProofVerifierInput> CCertProofVerifierInputPtr;
@@ -120,16 +120,16 @@ public:
     virtual void LoadDataForCertVerification(const CCoinsViewCache& view, const CScCertificate& scCert, CNode* pfrom = nullptr);
 
     virtual void LoadDataForCswVerification(const CCoinsViewCache& view, const CTransaction& scTx, CNode* pfrom = nullptr);
-    bool BatchVerify() const;
+    bool BatchVerify();
 
 protected:
     //std::map</*scTxHash*/uint256, std::vector<CCswProofVerifierInput>> cswEnqueuedData;      /**< The queue of CSW proofs to be verified. */
     //std::map</*certHash*/uint256, std::vector<CCertProofVerifierInput>> certEnqueuedData;    /**< The queue of certificate proofs to be verified. */
     std::map</* Cert or Tx hash */ uint256, CProofVerifierItem> proofQueue;   /** The queue of proofs to be verified. */
 
-    std::pair<bool, std::map<uint256, ProofVerifierOutput>> BatchVerifyInternal(const std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs) const;
+    bool BatchVerifyInternal(std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs);
 
-    std::map<uint256, ProofVerifierOutput> NormalVerify(const std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs) const;
+    void NormalVerify(std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs);
     ProofVerificationResult NormalVerifyCertificate(CCertProofVerifierInput input) const;
     ProofVerificationResult NormalVerifyCsw(std::vector<CCswProofVerifierInput> cswInputs) const;
 
@@ -139,8 +139,8 @@ private:
 
     const Verification verificationMode;    /**< The type of verification to be performed by this instance of proof verifier. */
 
-    std::map<uint256, ProofVerifierOutput> GenerateVerifierResults(const std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs,
-                                                                   ProofVerificationResult defaultResult) const;
+    //std::map<uint256, ProofVerifierOutput> GenerateVerifierResults(const std::map</* Cert or Tx hash */ uint256, CProofVerifierItem>& proofs,
+    //                                                               ProofVerificationResult defaultResult) const;
 };
 
 #endif // _SC_PROOF_VERIFIER_H

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -115,6 +115,11 @@ protected:
     std::pair<bool, std::map<uint256, ProofVerifierOutput>> BatchVerifyInternal(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
                                                                                 const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs) const;
 
+    std::map<uint256, ProofVerifierOutput> NormalVerify(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
+                                                        const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs) const;
+    ProofVerificationResult NormalVerifyCertificate(CCertProofVerifierItem input) const;
+    ProofVerificationResult NormalVerifyCsw(std::vector<CCswProofVerifierItem> cswInputs) const;
+
 private:
 
     static std::atomic<uint32_t> proofIdCounter;   /**< The counter used to get a unique ID for proofs. */
@@ -122,8 +127,8 @@ private:
     const Verification verificationMode;    /**< The type of verification to be performed by this instance of proof verifier. */
 
     std::map<uint256, ProofVerifierOutput> GenerateVerifierResults(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
-                                                                       const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs,
-                                                                       ProofVerificationResult defaultResult) const;
+                                                                   const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs,
+                                                                   ProofVerificationResult defaultResult) const;
 };
 
 #endif // _SC_PROOF_VERIFIER_H

--- a/src/sc/proofverifier.h
+++ b/src/sc/proofverifier.h
@@ -14,6 +14,67 @@ class CScCertificate;
 class uint256;
 class CCoinsViewCache;
 
+/**
+ * @brief The base struct for items added to the queue of the proof verifier.
+ */
+struct CBaseProofVerifierItem
+{
+    uint32_t proofId;                               /**< A unique number identifying the proof. */
+    std::shared_ptr<CTransactionBase> parentPtr;    /**< The parent (Transaction or Certificate) that owns the item (CSW input or certificate itself). */
+    CNode* node;                                    /**< The node that sent the parent (Transaction or Certiticate). */
+    CScProof proof;                                 /**< The proof to be verified. */
+    CScVKey verificationKey;                        /**< The key to be used for the verification. */
+};
+
+/**
+ * @brief A structure that includes all the arguments needed for verifying the proof of a CSW input.
+ */
+struct CCswProofVerifierItem : CBaseProofVerifierItem
+{
+    CFieldElement ceasingCumScTxCommTree;
+    CFieldElement certDataHash;
+    CAmount nValue;
+    CFieldElement nullifier;
+    uint160 pubKeyHash;
+    uint256 scId;
+};
+
+/**
+ * @brief A structure that includes all the arguments needed for verifying the proof of a certificate.
+ */
+struct CCertProofVerifierItem : CBaseProofVerifierItem
+{
+    uint256 certHash;
+    CFieldElement constant;
+    uint32_t epochNumber;
+    uint64_t quality;
+    std::vector<backward_transfer_t> bt_list;
+    std::vector<CFieldElement> vCustomFields;
+    CFieldElement endEpochCumScTxCommTreeRoot;
+    uint64_t mainchainBackwardTransferRequestScFee;
+    uint64_t forwardTransferScFee;
+};
+
+/**
+ * The enumeration of possible results of the proof verifier for any proof processed.
+ */
+enum ProofVerificationResult
+{
+    Unknown,    /**< The result of the batch verification is unknown. */
+    Failed,     /**< The proof verification failed. */
+    Passed      /**< The proof verification passed. */
+};
+
+/**
+ * @brief A structure containing the output data of a proof verification.
+ */
+struct ProofVerifierOutput
+{
+    std::shared_ptr<CTransactionBase> tx;    /**< The transaction which the proof verification refers to. */
+    CNode* node;                             /**< The node that sent the transaction. */
+    ProofVerificationResult proofResult;     /**< The result of the proof verification. */
+};
+
 /* Class for instantiating a verifier that is able to verify different kind of ScProof for different kind of ScProof(s) */
 class CScProofVerifier
 {
@@ -28,8 +89,8 @@ public:
         Loose       /**< Skip verification. */
     };
 
-    static CCertProofVerifierInput CertificateToVerifierInput(const CScCertificate& certificate, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
-    static CCswProofVerifierInput CswInputToVerifierInput(const CTxCeasedSidechainWithdrawalInput& cswInput, const CTransaction* cswTransaction, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
+    static CCertProofVerifierItem CertificateToVerifierItem(const CScCertificate& certificate, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
+    static CCswProofVerifierItem CswInputToVerifierItem(const CTxCeasedSidechainWithdrawalInput& cswInput, const CTransaction* cswTransaction, const Sidechain::ScFixedParameters& scFixedParams, CNode* pfrom);
 
     CScProofVerifier(Verification mode) :
     verificationMode(mode)
@@ -47,8 +108,12 @@ public:
     bool BatchVerify() const;
 
 protected:
-    std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>> cswEnqueuedData; /**< The queue of CSW proofs to be verified. */
-    std::map</*certHash*/uint256, CCertProofVerifierInput> certEnqueuedData;    /**< The queue of certificate proofs to be verified. */
+    std::map</*scTxHash*/uint256, std::vector<CCswProofVerifierItem>> cswEnqueuedData;      /**< The queue of CSW proofs to be verified. */
+    std::map</*certHash*/uint256, std::vector<CCertProofVerifierItem>> certEnqueuedData;    /**< The queue of certificate proofs to be verified. */
+    //std::map</* Cert or Tx hash */ uint256, std::vector<CBaseProofVerifierItem*>> proofQueue;   /** The queue of proofs to be verified. */
+
+    std::pair<bool, std::map<uint256, ProofVerifierOutput>> BatchVerifyInternal(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
+                                                                                const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs) const;
 
 private:
 
@@ -56,9 +121,9 @@ private:
 
     const Verification verificationMode;    /**< The type of verification to be performed by this instance of proof verifier. */
 
-    std::pair<bool, std::vector<uint32_t>> BatchVerifyInternal(
-                                            const std::map</*scTxHash*/uint256, std::map</*outputPos*/unsigned int, CCswProofVerifierInput>>& cswInputs,
-                                            const std::map</*certHash*/uint256, CCertProofVerifierInput>& certInputs) const;
+    std::map<uint256, ProofVerifierOutput> GenerateVerifierResults(const std::map</* Tx hash */ uint256, std::vector<CCswProofVerifierItem>>& cswProofs,
+                                                                       const std::map</* Cert hash */ uint256, std::vector<CCertProofVerifierItem>>& certProofs,
+                                                                       ProofVerificationResult defaultResult) const;
 };
 
 #endif // _SC_PROOF_VERIFIER_H


### PR DESCRIPTION
This PR makes Zendoo take advantage of the optimizations of the CCTP library about the handling of failures during the verification of certificate and CSW transaction proofs.

The CScAsyncProofVerifier now works like this:

1. Performs a batch verification
2. If there is a failure and the CCTP library returns the ID of failing proofs, they are removed from the queue
3. Performs a new batch verification with the remaining proofs
4. If still there is a failure, the CCTP library for sure is not able to return the failing IDs, so as last chance the proofs are processed one by one

During the implementation of such changes, some refactoring has been made to simplify the proof verification classes and to reduce duplication:

- There is now a single queue for proofs, containing both certificates and CSW inputs
- Some code of the async proof verifier has been moved to the generic proof verifier
- The ProofVerifierOutput structure has been removed, the result of the verification is now stored in the queue item itself.