### PR TITLE
As/issue 127 135 138

### DIFF
--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -137,11 +137,13 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
         self.sync_all()
 
         sc_fork_reached = False
-        mark_logs(("active chain height = %d: testing before sidechain fork" %  self.nodes[0].getblockcount()), self.nodes, DEBUG_MODE)
+        currentHeight = self.nodes[0].getblockcount()
+        mark_logs(("active chain height = %d: testing before sidechain fork" % currentHeight), self.nodes, DEBUG_MODE)
         self.doTest(sc_fork_reached)
 
         # reach the height where the next block is the last before the fork point where certificates are supported
-        self.nodes[0].generate((MINIMAL_SC_HEIGHT - 1) - 200 - 2) 
+        delta = MINIMAL_SC_HEIGHT - currentHeight - 2;
+        self.nodes[0].generate(delta) 
         self.sync_all()
 
         mark_logs(("active chain height = %d: testing last block before sidechain fork" %  self.nodes[0].getblockcount()), self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/getblocktemplate_proposals.py
+++ b/qa/rpc-tests/getblocktemplate_proposals.py
@@ -140,11 +140,18 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
         mark_logs(("active chain height = %d: testing before sidechain fork" %  self.nodes[0].getblockcount()), self.nodes, DEBUG_MODE)
         self.doTest(sc_fork_reached)
 
-        # reach the fork where certificates are supported
-        self.nodes[0].generate(MINIMAL_SC_HEIGHT-200) 
+        # reach the height where the next block is the last before the fork point where certificates are supported
+        self.nodes[0].generate((MINIMAL_SC_HEIGHT - 1) - 200 - 2) 
         self.sync_all()
 
-        mark_logs(("active chain height = %d: testing after sidechain fork" %  self.nodes[0].getblockcount()), self.nodes, DEBUG_MODE)
+        mark_logs(("active chain height = %d: testing last block before sidechain fork" %  self.nodes[0].getblockcount()), self.nodes, DEBUG_MODE)
+        self.doTestJustBeforeScFork()
+
+        # reach the fork where certificates are supported
+        self.nodes[0].generate(1) 
+        self.sync_all()
+
+        mark_logs(("active chain height = %d: testing block which will be at sidechain fork" %  self.nodes[0].getblockcount()), self.nodes, DEBUG_MODE)
         sc_fork_reached = True
 
         # create a sidechain and a certificate for it in the mempool
@@ -191,6 +198,43 @@ class GetBlockTemplateProposalTest(BitcoinTestFramework):
 
         self.nodes[0].generate(1) 
         self.sync_all()
+
+
+    def doTestJustBeforeScFork(self):
+
+        node = self.nodes[0]
+
+        tmpl = node.getblocktemplate()
+        if 'coinbasetxn' not in tmpl:
+            rawcoinbase = encodeUNum(tmpl['height'])
+            rawcoinbase += b'\x01-'
+            hexcoinbase = b2x(rawcoinbase)
+            hexoutval = b2x(pack('<Q', tmpl['coinbasevalue']))
+            tmpl['coinbasetxn'] = {'data': '01000000' + '01' + '0000000000000000000000000000000000000000000000000000000000000000ffffffff' + ('%02x' % (len(rawcoinbase),)) + hexcoinbase + 'fffffffe' + '01' + hexoutval + '00' + '00000000'}
+        txlist = list(bytearray(a2b_hex(a['data'])) for a in (tmpl['coinbasetxn'],) + tuple(tmpl['transactions']))
+        certlist = []
+
+        # Test: set a non-zero 'hashReserved' field (32 bytes after mkl tree field); this is used from the sc fork on, renamed as 'scTxsCommitment'
+        rawtmpl = template_to_bytes(tmpl, txlist, certlist)
+
+        # a 32 null byte array string
+        nb1 = b2x(bytearray(32))
+
+        nb2 = b2x(rawtmpl[4+32+32:4+32+32+32])
+        # check hashReserved field is currently null 
+        assert_true(nb1 == nb2)
+
+        for j in range(0,32):
+            rawtmpl[4+32+32+j] = j
+
+        # hashReserved is not null now
+        nb3 = b2x(rawtmpl[4+32+32:4+32+32+32])
+        assert_false(nb3 == nb2)
+
+        rsp = node.getblocktemplate({'data':b2x(rawtmpl),'mode':'proposal'})
+        # assert block validity
+        assert_equal(rsp, None)
+
 
 
     def doTest(self, sc_fork_reached):

--- a/src/gtest/test_forkmanager.cpp
+++ b/src/gtest/test_forkmanager.cpp
@@ -226,3 +226,63 @@ TEST(ForkManager, FutureTimeStampRegtest) {
 	EXPECT_EQ(ForkManager::getInstance().isFutureMiningTimeStampActive(futureTimeStampActivation), true);
 	EXPECT_EQ(ForkManager::getInstance().isFutureTimeStampActive(futureTimeStampActivation), true);
 }
+
+TEST(ForkManager, SidechainForkRegtest) {
+	SelectParams(CBaseChainParams::REGTEST);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(0), false);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(419), false);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(420), true);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(421), true);
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(0), 0);
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(419), 0);
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(420), SC_TX_VERSION);
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(421), SC_TX_VERSION);
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(0), 0);
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(419), 0);
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(420), SC_CERT_VERSION);
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(421), SC_CERT_VERSION);
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(0), BLOCK_VERSION_ORIGINAL);
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(419), BLOCK_VERSION_BEFORE_SC);
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(420), BLOCK_VERSION_SC_SUPPORT);
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(421), BLOCK_VERSION_SC_SUPPORT);
+}
+
+TEST(ForkManager, SidechainForkTestnet) {
+	SelectParams(CBaseChainParams::TESTNET);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(0), false);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(749999), false); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(750000), true);  // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(750001), true);  // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(0), 0);
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(749999), 0);             // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(750000), SC_TX_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(750001), SC_TX_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(0), 0);
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(749999), 0);               // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(750000), SC_CERT_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(750001), SC_CERT_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(0), BLOCK_VERSION_ORIGINAL);
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(749999), BLOCK_VERSION_BEFORE_SC);  // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(750000), BLOCK_VERSION_SC_SUPPORT); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(750001), BLOCK_VERSION_SC_SUPPORT); // TODO modify according to fork8_sidechainfork.cpp
+}
+
+TEST(ForkManager, SidechainForkMainnet) {
+	SelectParams(CBaseChainParams::MAIN);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(0), false);
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(999998), false); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(999999), true);  // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().areSidechainsSupported(1000000), true); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(0), 0);
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(999998), 0);             // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(999999), SC_TX_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getSidechainTxVersion(1000000), SC_TX_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(0), 0);
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(999998), 0);               // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(999999), SC_CERT_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getCertificateVersion(1000000), SC_CERT_VERSION); // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(0), BLOCK_VERSION_ORIGINAL);
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(999998), BLOCK_VERSION_BEFORE_SC);   // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(999999), BLOCK_VERSION_SC_SUPPORT);  // TODO modify according to fork8_sidechainfork.cpp
+	EXPECT_EQ(ForkManager::getInstance().getNewBlockVersion(1000000), BLOCK_VERSION_SC_SUPPORT); // TODO modify according to fork8_sidechainfork.cpp
+}

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -755,7 +755,12 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn,  unsigned int nBlo
 
         // Fill in header
         pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-        pblock->hashScTxsCommitment = pblock->BuildScTxsCommitment(view);
+
+        if (pblock->nVersion == BLOCK_VERSION_SC_SUPPORT )
+        {
+            pblock->hashScTxsCommitment = pblock->BuildScTxsCommitment(view);
+        }
+
         UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
         pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, Params().GetConsensus());
         pblock->nSolution.clear();


### PR DESCRIPTION
- Added test coverage in UT for fork8 sidechain fork (issue #127)
- Miner sets hashScTxsCommitment field in block (formerly hashReserved) only if it supports sidechains (issue #135)
- Added a section in py test for testing that hashReserved block field can also have non null contents in the last block before sidechains fork (issue #138)

