### PR TITLE
Removed the duplicated 'scTxsCommitment' field in 'getblock' response

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -192,7 +192,6 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
     result.pushKV("anchor", blockindex->hashAnchorEnd.GetHex());
-    result.pushKV("scTxsCommitment", blockindex->hashScTxsCommitment.GetHex());
     result.pushKV("scCumTreeHash", blockindex->scCumTreeHash.GetHexRepr());
 
     UniValue valuePools(UniValue::VARR);


### PR DESCRIPTION
Removed the duplicated field `scTxsCommitment` in the response returned by the RPC call `getblock`.

Closes #174.