### PR TITLE
Added PROOF_PLUS_VK_SIZE constant and check it for certs and csws. Bug fix in proof/vk isValid().

### DIFF
--- a/depends/packages/libzendoo.mk
+++ b/depends/packages/libzendoo.mk
@@ -3,8 +3,8 @@ $(package)_version=0.1.0
 $(package)_download_path=https://github.com/HorizenOfficial/zendoo-mc-cryptolib/archive/
 $(package)_file_name=$(package)-$($(package)_git_commit).tar.gz
 $(package)_download_file=$($(package)_git_commit).tar.gz
-$(package)_sha256_hash=8d207c8ec9a2baa188f6c5755788a7813788374ed35c2d83f6958a7c9fb8076f
-$(package)_git_commit=9d29eaf9b63b62dc9d73579952f9c943186d3f11
+$(package)_sha256_hash=779963eb29a8f0f8c23b0d5c124e89b60c78178fce3adfd23734a0add7511696
+$(package)_git_commit=60d2e8320bb85f844e079948d2ae6c75e26c8cfd
 $(package)_dependencies=rust $(rust_crates_z)
 $(package)_patches=cargo.config
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -1205,6 +1205,16 @@ CValidationState::Code CCoinsViewCache::IsCertApplicableToState(const CScCertifi
         return CValidationState::Code::INSUFFICIENT_SCID_FUNDS;
     }
 
+    size_t proof_plus_vk_size = sidechain.fixedParams.wCertVk.GetByteArray().size() + cert.scProof.GetByteArray().size();
+    if(proof_plus_vk_size > Sidechain::MAX_PROOF_PLUS_VK_SIZE)
+    {
+        LogPrintf("%s():%d - ERROR: Cert [%s]\n proof plus vk size (%d) exceeded the limit %d\n",
+            __func__, __LINE__, certHash.ToString(), proof_plus_vk_size, Sidechain::MAX_PROOF_PLUS_VK_SIZE);
+        if (banSenderNode)
+            *banSenderNode = true;
+        return CValidationState::Code::INVALID;
+    }
+
     LogPrint("sc", "%s():%d - ok, balance in scId[%s]: balance[%s], cert amount[%s]\n",
         __func__, __LINE__, cert.GetScId().ToString(), FormatMoney(scBalance), FormatMoney(bwtTotalAmount) );
 
@@ -1494,6 +1504,16 @@ CValidationState::Code CCoinsViewCache::IsScTxApplicableToState(const CTransacti
         {
             LogPrintf("%s():%d - ERROR: Tx[%s] CSW input [%s]\n refers to SC without CSW support\n",
                 __func__, __LINE__, tx.GetHash().ToString(), csw.ToString());
+            if (banSenderNode)
+                *banSenderNode = true;
+            return CValidationState::Code::INVALID;
+        }
+
+        size_t proof_plus_vk_size = sidechain.fixedParams.wCeasedVk.get().GetByteArray().size() + csw.scProof.GetByteArray().size();
+        if(proof_plus_vk_size > Sidechain::MAX_PROOF_PLUS_VK_SIZE)
+        {
+            LogPrintf("%s():%d - ERROR: Tx[%s] CSW input [%s]\n proof plus vk size (%d) exceeded the limit %d\n",
+                __func__, __LINE__, tx.GetHash().ToString(), csw.ToString(), proof_plus_vk_size, Sidechain::MAX_PROOF_PLUS_VK_SIZE);
             if (banSenderNode)
                 *banSenderNode = true;
             return CValidationState::Code::INVALID;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -47,9 +47,19 @@ static const unsigned int MAX_TX_SIZE = 100000;
 static const unsigned int MAX_CERT_SIZE = 150000;
 /** The minimum theoretical possible size of a consistent tx*/
 static const unsigned int MIN_TX_SIZE = 61;
+static const unsigned int MIN_LOG_SEGMENT_SIZE = 0;
+/** Computed assuming:
+ * 1) SegmentSize = MIN_LOG_SEGMENT_SIZE;
+ * 2) One segment commitment for each polynomial;
+ * 3) ProvingSystemType = CoboundaryMarlin;
+ * 4) ZK = False
+*/
+static const unsigned int MIN_PROOF_SIZE = 1086 + (2 * MIN_LOG_SEGMENT_SIZE * 33);
 /** The minimum theoretical possible size of a consistent cert.
- *  Large of its part is taken by the proof, which has a the minimum theoretical possible size of ~2850 */
-static const unsigned int MIN_CERT_SIZE = 2950;
+ *  Large of its part is taken by the proof, which has a the minimum theoretical possible size of ~1086
+ *  (was 2850 assuming SegmentSize = 1 << 18) */
+static const unsigned int MIN_CERT_SIZE = MIN_PROOF_SIZE + 100;
+    
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/gtest/test_libzendoo.cpp
+++ b/src/gtest/test_libzendoo.cpp
@@ -1928,3 +1928,51 @@ TEST(CctpLibrary, TestVectorsValidity)
     EXPECT_TRUE(p4.IsValid());
 }
 
+//TODO: Maybe it's not the correct place for this test
+TEST(CctpLibrary, TestInvalidProofVkWhenOversized)
+{
+    // Oversized Proof
+    std::vector<unsigned char> OVERSIZED_CERT_DARLIN_PROOF = SAMPLE_CERT_DARLIN_PROOF;
+    OVERSIZED_CERT_DARLIN_PROOF.resize(OVERSIZED_CERT_DARLIN_PROOF.size() + Sidechain::MAX_SC_PROOF_SIZE_IN_BYTES, 0xAB);
+    EXPECT_DEATH(CScProof{OVERSIZED_CERT_DARLIN_PROOF}, "");
+    
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << OVERSIZED_CERT_DARLIN_PROOF;
+    CScProof pOversized;
+    stream >> pOversized;
+    EXPECT_FALSE(pOversized.IsValid());
+
+    // Not oversized proof but with random bytes appended to proof bytes
+    std::vector<unsigned char> INVALID_CERT_DARLIN_PROOF = SAMPLE_CERT_DARLIN_PROOF;
+    INVALID_CERT_DARLIN_PROOF.push_back(0xAB);
+    EXPECT_NO_FATAL_FAILURE(CScProof{INVALID_CERT_DARLIN_PROOF});
+
+    stream << INVALID_CERT_DARLIN_PROOF;
+    CScProof pInvalid;
+    stream >> pInvalid;
+    //TODO: Currently fails. We need to modify mc-cryptolib in order to return error even the proof
+    //      is deserialized correctly, but there are still bytes to read.
+    //EXPECT_FALSE(pInvalid.IsValid());
+
+    // Oversized vk
+    std::vector<unsigned char> OVERSIZED_CERT_DARLIN_VK = SAMPLE_CERT_DARLIN_VK;
+    OVERSIZED_CERT_DARLIN_VK.resize(OVERSIZED_CERT_DARLIN_VK.size() + Sidechain::MAX_SC_VK_SIZE_IN_BYTES, 0xAB);
+    EXPECT_DEATH(CScVKey{OVERSIZED_CERT_DARLIN_VK}, "");
+
+    stream << OVERSIZED_CERT_DARLIN_VK;
+    CScVKey vkOversized;
+    stream >> vkOversized;
+    EXPECT_FALSE(vkOversized.IsValid());
+
+    // Not oversized vk but with random bytes appended to vk bytes
+    std::vector<unsigned char> INVALID_CERT_DARLIN_VK = SAMPLE_CERT_DARLIN_VK;
+    INVALID_CERT_DARLIN_VK.push_back(0xAB);
+    EXPECT_NO_FATAL_FAILURE(CScVKey{INVALID_CERT_DARLIN_VK});
+
+    stream << INVALID_CERT_DARLIN_VK;
+    CScVKey vkInvalid;
+    stream >> vkInvalid;
+    //TODO: Currently fails. We need to modify mc-cryptolib in order to return error even the proof
+    //      is deserialized correctly, but there are still bytes to read.
+    //EXPECT_FALSE(vkInvalid.IsValid());
+}

--- a/src/gtest/test_libzendoo.cpp
+++ b/src/gtest/test_libzendoo.cpp
@@ -1950,9 +1950,7 @@ TEST(CctpLibrary, TestInvalidProofVkWhenOversized)
     stream << INVALID_CERT_DARLIN_PROOF;
     CScProof pInvalid;
     stream >> pInvalid;
-    //TODO: Currently fails. We need to modify mc-cryptolib in order to return error even the proof
-    //      is deserialized correctly, but there are still bytes to read.
-    //EXPECT_FALSE(pInvalid.IsValid());
+    EXPECT_FALSE(pInvalid.IsValid());
 
     // Oversized vk
     std::vector<unsigned char> OVERSIZED_CERT_DARLIN_VK = SAMPLE_CERT_DARLIN_VK;
@@ -1972,7 +1970,7 @@ TEST(CctpLibrary, TestInvalidProofVkWhenOversized)
     stream << INVALID_CERT_DARLIN_VK;
     CScVKey vkInvalid;
     stream >> vkInvalid;
-    //TODO: Currently fails. We need to modify mc-cryptolib in order to return error even the proof
-    //      is deserialized correctly, but there are still bytes to read.
-    //EXPECT_FALSE(vkInvalid.IsValid());
+    EXPECT_FALSE(vkInvalid.IsValid());
+
+    //TODO: Might be useful to test the same behaviour with bit vector
 }

--- a/src/sc/sidechaintypes.cpp
+++ b/src/sc/sidechaintypes.cpp
@@ -304,6 +304,14 @@ wrappedScProofPtr CScProof::GetProofPtr() const
     std::lock_guard<std::mutex> lk(_mutex);
     if (proofData == nullptr)
     {
+        if (byteVector.size() > MaxByteSize())
+        {
+            LogPrint("sc", "%s():%d - exceeded max size: byteVector[%d] != %d\n",
+                __func__, __LINE__, byteVector.size(), MaxByteSize());
+            assert(proofData == nullptr);
+            return proofData;
+        }
+
         BufferWithSize result{(unsigned char*)&byteVector[0], byteVector.size()}; 
         CctpErrorCode code;
 
@@ -382,6 +390,15 @@ wrappedScVkeyPtr CScVKey::GetVKeyPtr() const
     std::lock_guard<std::mutex> lk(_mutex);
     if (vkData == nullptr)
     {
+
+        if (byteVector.size() > MaxByteSize())
+        {
+            LogPrint("sc", "%s():%d - exceeded max size: byteVector[%d] != %d\n",
+                __func__, __LINE__, byteVector.size(), MaxByteSize());
+            assert(vkData == nullptr);
+            return vkData;
+        }
+
         BufferWithSize result{(unsigned char*)&byteVector[0], byteVector.size()}; 
         CctpErrorCode code;
 

--- a/src/sc/sidechaintypes.h
+++ b/src/sc/sidechaintypes.h
@@ -38,8 +38,9 @@ namespace Sidechain
     static_assert(MAX_SC_MBTR_DATA_LEN < UINT8_MAX, "MAX_SC_MBTR_DATA_LEN must be lower than max uint8_t size!");
 
     static const int SC_FE_SIZE_IN_BYTES        = 32;
-    static const int MAX_SC_PROOF_SIZE_IN_BYTES = 7*1024;
-    static const int MAX_SC_VK_SIZE_IN_BYTES    = 4*1024;
+    static const int MAX_PROOF_PLUS_VK_SIZE     = 9*1024;
+    static const int MAX_SC_PROOF_SIZE_IN_BYTES = MAX_PROOF_PLUS_VK_SIZE;
+    static const int MAX_SC_VK_SIZE_IN_BYTES    = MAX_PROOF_PLUS_VK_SIZE;
 
     static const int SEGMENT_SIZE = 1 << 18;
 }

--- a/src/undo.h
+++ b/src/undo.h
@@ -312,7 +312,7 @@ class CBlockUndo
      *  It is used for distinguish new version of CBlockUndo instance from old ones.
      *  The maximum number of tx+cert in a block is roughly:
      *      BLOCK_TX_PARTITION_SIZE / MIN_TX_SIZE + (MAX_BLOCK_SIZE - BLOCK_TX_PARTITION_SIZE) / MIN_CERT_SIZE =
-     *      2M / 61bytes + 2M / 2950bytes =~ 35K = 0x8912  
+     *      2M / 61bytes + 2M / 1186bytes =~ 35K = 0x8912  
      * Therefore the magic number must be a number greater than this limit. */
     static const uint64_t _marker = 0xffff;
 


### PR DESCRIPTION
Still need to address:

- Add a python test that checks that IsScTxApplicableToState and IsCertApplicableToState fail when proof + vk size exceeds the new limit just introduced. To do this we need to generate big proofs and vks in the python tests. It's enough to call the already existing functions using a small segment size and a big number of constraints;
- In zendoo-mc-cryptolib we need to return error whenever we deserialize succesfully variable sized data but there are still bytes to read.