### PR TITLE
As/issue 167

### DIFF
--- a/qa/rpc-tests/sc_bwt_request.py
+++ b/qa/rpc-tests/sc_bwt_request.py
@@ -294,10 +294,10 @@ class sc_bwt_request(BitcoinTestFramework):
 
         sc_info = self.nodes[0].getscinfo(scid1)['items'][0]
 
-        mark_logs("Check creation and bwt requests contributed to immature amount of SC", self.nodes, DEBUG_MODE)
-        # check immature amounts, both cr and btrs 
+        mark_logs("Check creation and bwt requests contributed to immatureAmount of SC", self.nodes, DEBUG_MODE)
+        # check immatureAmounts, both cr and btrs 
         ima = Decimal("0.0")
-        for x in sc_info['immature amounts']:
+        for x in sc_info['immatureAmounts']:
             ima = ima + x['amount']
             assert_equal(x['maturityHeight'], curh + SC_COINS_MAT) 
         assert_equal(ima, totScFee + creation_amount1)
@@ -406,10 +406,10 @@ class sc_bwt_request(BitcoinTestFramework):
         ret_sc2 = self.nodes[0].getscinfo(scid2, False, False)['items'][0]
 
         # get the submission window limit for SC1
-        sc1_cr_height=ret_sc1['created at block height']
-        sc1_ceas_h = ret_sc1['ceasing height']
+        sc1_cr_height=ret_sc1['createdAtBlockHeight']
+        sc1_ceas_h = ret_sc1['ceasingHeight']
         sc1_ceas_limit_delta = sc1_ceas_h - cur_h - 1
-        mark_logs("current height={}, creation height={}, ceasing height={}, ceas_limit_delta={}, epoch_len={}"
+        mark_logs("current height={}, creation height={}, ceasingHeight={}, ceas_limit_delta={}, epoch_len={}"
             .format(cur_h, sc1_cr_height, sc1_ceas_h, sc1_ceas_limit_delta, EPOCH_LENGTH), self.nodes, DEBUG_MODE)
 
         mark_logs("Node0 generates {} blocks reaching the submission window height for SC1".format(sc1_ceas_limit_delta), self.nodes, DEBUG_MODE)
@@ -463,7 +463,7 @@ class sc_bwt_request(BitcoinTestFramework):
         sc_post_bwd = self.nodes[0].getscinfo(scid1, False, False)['items'][0]
         assert_equal(sc_post_bwd["balance"], totScFee)
 
-        ceasing_h = int(sc_post_bwd['ceasing height'])
+        ceasing_h = int(sc_post_bwd['ceasingHeight'])
         current_h = self.nodes[0].getblockcount()
 
         mark_logs("Node0 generates {} blocks moving on the ceasing limit of SC1".format(ceasing_h - current_h - 1), self.nodes, DEBUG_MODE)
@@ -543,7 +543,7 @@ class sc_bwt_request(BitcoinTestFramework):
 
         ret = self.nodes[0].getscinfo(scid2, False, False)['items'][0]
 
-        ceasing_h = int(ret['ceasing height'])
+        ceasing_h = int(ret['ceasingHeight'])
         current_h = self.nodes[0].getblockcount()
 
         mark_logs("Node0 generates {} blocks moving on the ceasing limit of SC2".format(ceasing_h - current_h - 1), self.nodes, DEBUG_MODE)
@@ -556,7 +556,7 @@ class sc_bwt_request(BitcoinTestFramework):
         # 1) send a cert
         mark_logs("\nNode0 sends a certificate to SC2", self.nodes, DEBUG_MODE)
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid2, self.nodes[0], epoch_len_2)
-        sc_creating_height = self.nodes[0].getscinfo(scid2)['items'][0]['created at block height']
+        sc_creating_height = self.nodes[0].getscinfo(scid2)['items'][0]['createdAtBlockHeight']
         epoch_block_hash = self.nodes[0].getblockhash(sc_creating_height - 1 + ((epoch_number + 1) * epoch_len_2))
 
         bt_amount = Decimal("1.0")

--- a/qa/rpc-tests/sc_cert_base.py
+++ b/qa/rpc-tests/sc_cert_base.py
@@ -107,7 +107,7 @@ class sc_cert_base(BitcoinTestFramework):
         assert_equal(bal_before_sc_creation, bal_after_sc_creation + creation_amount - fee_sc_creation)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to Sc
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -129,15 +129,15 @@ class sc_cert_base(BitcoinTestFramework):
         assert_equal(bal_before_fwd_tx, bal_after_fwd_tx + fwt_amount - fee_fwt - Decimal(MINER_REWARD_POST_H200))
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][1]['amount'], fwt_amount)
 
         nblocks = EPOCH_LENGTH - 2
         mark_logs("Node0 generating {} more blocks to achieve end of withdrawal epoch".format(nblocks), self.nodes, DEBUG_MODE)
         self.nodes[0].generate(nblocks)
         self.sync_all()
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
         mark_logs("epoch_number = {}, epoch_cum_tree_hash = {}".format(epoch_number, epoch_cum_tree_hash), self.nodes, DEBUG_MODE)
@@ -166,7 +166,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("sidechain has insufficient funds" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount)
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
         #--------------------------------------------------------------------------------------
 
         mark_logs("Node 0 tries to send a certificate with an invalid epoch number ...", self.nodes, DEBUG_MODE)
@@ -183,7 +183,7 @@ class sc_cert_base(BitcoinTestFramework):
         #      This error message is expected; e.g. the send certificate fails for the correct reason
         assert_equal("invalid end cum commitment tree root" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
         #--------------------------------------------------------------------------------------
 
         mark_logs("Node 0 tries to send a certificate with an invalid epoch epoch_cum_tree_hash ...", self.nodes, DEBUG_MODE)
@@ -199,7 +199,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("invalid end cum commitment tree root" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
         #--------------------------------------------------------------------------------------
 
         mark_logs("Node 0 tries to send a certificate with an invalid quality ...", self.nodes, DEBUG_MODE)
@@ -214,7 +214,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("Invalid quality parameter" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
         #--------------------------------------------------------------------------------------
         
         mark_logs("Node 0 tries to send a certificate with a scProof too long ...", self.nodes, DEBUG_MODE)
@@ -229,7 +229,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("scProof: Invalid length" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -245,7 +245,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("invalid cert scProof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -264,7 +264,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
         
         #--------------------------------------------------------------------------------------
 
@@ -284,7 +284,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -303,7 +303,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -322,7 +322,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -341,7 +341,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -360,7 +360,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -380,7 +380,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #--------------------------------------------------------------------------------------
 
@@ -409,18 +409,18 @@ class sc_cert_base(BitcoinTestFramework):
 
         assert_equal("bad-sc-cert-proof" in errorString, True)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc has not been affected by faulty certificate
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         #---------------------end negative tests-------------------------
 
         cur_h = self.nodes[0].getblockcount()
 
         ret=self.nodes[0].getscinfo(scid, True, False)['items'][0]
-        cr_height=ret['created at block height']
-        ceas_h = ret['ceasing height']
+        cr_height=ret['createdAtBlockHeight']
+        ceas_h = ret['ceasingHeight']
         ceas_limit_delta = ceas_h - cur_h -1
 
-        mark_logs("epoch number={}, current height={}, creation height={}, ceasing height={}, ceas_limit_delta={}, epoch_len={}"
+        mark_logs("epoch number={}, current height={}, creation height={}, ceasingHeight={}, ceas_limit_delta={}, epoch_len={}"
             .format(epoch_number, cur_h, cr_height, ceas_h, ceas_limit_delta, EPOCH_LENGTH), self.nodes, DEBUG_MODE)
         print
 
@@ -486,7 +486,7 @@ class sc_cert_base(BitcoinTestFramework):
         # Check that BT is immature
         utx_out = self.nodes[0].gettxout(cert_epoch_0, 1, False, mature_only)
         cur_h = self.nodes[0].getblockcount()
-        cert_epoch_0_maturity_h = self.nodes[0].getscinfo(scid, True, False)['items'][0]['ceasing height']
+        cert_epoch_0_maturity_h = self.nodes[0].getscinfo(scid, True, False)['items'][0]['ceasingHeight']
         cert_epoch_0_maturity_delta = cert_epoch_0_maturity_h - cur_h - 1
         assert_equal(utx_out["mature"], False)
         assert_equal(utx_out["maturityHeight"], cert_epoch_0_maturity_h)
@@ -517,7 +517,7 @@ class sc_cert_base(BitcoinTestFramework):
         miner_quota = decoded_coinbase['vout'][0]['value']
         assert_equal(miner_quota, (Decimal(MINER_REWARD_POST_H200) + CERT_FEE))
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount- amount_cert_1[0]["amount"])
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         mark_logs("Checking that amount transferred by epoch 0 certificate is not mature", self.nodes, DEBUG_MODE)
         retrieved_cert = self.nodes[1].gettransaction(cert_epoch_0)
@@ -547,7 +547,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         cur_h = self.nodes[0].getblockcount()
         ret=self.nodes[0].getscinfo(scid, True, False)['items'][0]
-        next_ep_h = ret['end epoch height']
+        next_ep_h = ret['endEpochHeight']
         next_ep_delta = next_ep_h - cur_h
 
         mark_logs("Show that coins from bwt can be spent once next epoch certificate is received and confirmed", self.nodes, DEBUG_MODE)
@@ -593,15 +593,15 @@ class sc_cert_base(BitcoinTestFramework):
         self.sync_all()
 
         ret=self.nodes[0].getscinfo(scid, True, False)['items'][0]
-        cr_height=ret['created at block height']
+        cr_height=ret['createdAtBlockHeight']
 
         epoch_number_0        = epoch_number
         epoch_cum_tree_hash_0 = epoch_cum_tree_hash
         cur_h = self.nodes[0].getblockcount()
-        ceas_h = ret['ceasing height']
+        ceas_h = ret['ceasingHeight']
         delta = ceas_h - cur_h - 1 - EPOCH_LENGTH
 
-        mark_logs("epoch number={}, current height={}, creation height={}, ceasing height={}, delta={}, epoch_len={}"
+        mark_logs("epoch number={}, current height={}, creation height={}, ceasingHeight={}, delta={}, epoch_len={}"
             .format(epoch_number, cur_h, cr_height, ceas_h, delta, EPOCH_LENGTH), self.nodes, DEBUG_MODE)
         print
 

--- a/qa/rpc-tests/sc_cert_ceasing.py
+++ b/qa/rpc-tests/sc_cert_ceasing.py
@@ -167,7 +167,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
                     assert_equal(sc_info["state"], "CEASED")
                 else:
                     assert_equal(sc_info["state"], "ALIVE")
-                assert_equal(sc_info["last certificate epoch"], last_cert_epochs[k])
+                assert_equal(sc_info["lastCertificateEpoch"], last_cert_epochs[k])
                 assert_equal(sc_info["balance"], creation_amount[k] - bwt_amount[k])
 
         bal1 = self.nodes[1].getbalance()
@@ -204,7 +204,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
                 print "idx = {}, k = {}".format(idx, k)
                 sc_info = node.getscinfo(scids[k])['items'][0]
                 assert_equal(sc_info["state"], "CEASED")
-                assert_equal(sc_info["last certificate epoch"], last_cert_epochs[k])
+                assert_equal(sc_info["lastCertificateEpoch"], last_cert_epochs[k])
                 assert_equal(sc_info["balance"], creation_amount[k] - bwt_amount[k])
 
         mark_logs("Node 0 tries to fwd coins to ceased sc {}...".format(scids[-1]), self.nodes, DEBUG_MODE)
@@ -227,7 +227,7 @@ class sc_cert_ceasing(BitcoinTestFramework):
                 mark_logs("Checking Node{} after restart".format(idx), self.nodes, DEBUG_MODE)
                 sc_post_regeneration = node.getscinfo(scids[k])['items'][0]
                 assert_equal(sc_post_regeneration["state"], "CEASED")
-                assert_equal(sc_post_regeneration["last certificate epoch"], last_cert_epochs[k])
+                assert_equal(sc_post_regeneration["lastCertificateEpoch"], last_cert_epochs[k])
                 assert_equal(sc_post_regeneration["balance"], creation_amount[k] - bwt_amount[k])
 
         bal1 = self.nodes[1].getbalance()

--- a/qa/rpc-tests/sc_cert_ceasing_sg.py
+++ b/qa/rpc-tests/sc_cert_ceasing_sg.py
@@ -106,9 +106,9 @@ class sc_cert_ceasing_sg(BitcoinTestFramework):
 
         ret = self.nodes[0].getscinfo(scid, False, False)['items'][0]
         pprint.pprint(ret)
-        assert_equal(ret['created at block height'], MINIMAL_SC_HEIGHT+1)
-        assert_equal(ret['end epoch height'], MINIMAL_SC_HEIGHT+EPOCH_LENGTH)
-        assert_equal(ret['ceasing height'], MINIMAL_SC_HEIGHT+EPOCH_LENGTH+EPOCH_LENGTH/5)
+        assert_equal(ret['createdAtBlockHeight'], MINIMAL_SC_HEIGHT+1)
+        assert_equal(ret['endEpochHeight'], MINIMAL_SC_HEIGHT+EPOCH_LENGTH)
+        assert_equal(ret['ceasingHeight'], MINIMAL_SC_HEIGHT+EPOCH_LENGTH+EPOCH_LENGTH/5)
         assert_equal(ret['epoch'], 0)
         assert_equal(ret['scid'], scid)
         assert_equal(ret['withdrawalEpochLength'], EPOCH_LENGTH)
@@ -137,11 +137,11 @@ class sc_cert_ceasing_sg(BitcoinTestFramework):
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
 
         ret = self.nodes[0].getscinfo(scid, False, False)['items'][0]
-        print "ceasing height   =", ret['ceasing height']
-        print "end epoch height =", ret['end epoch height']
+        print "ceasingHeight   =", ret['ceasingHeight']
+        print "endEpochHeight =", ret['endEpochHeight']
         print "epoch number     =", ret['epoch']
-        assert_equal(ret['ceasing height'], MINIMAL_SC_HEIGHT+2*EPOCH_LENGTH+EPOCH_LENGTH/5) 
-        assert_equal(ret['end epoch height'], MINIMAL_SC_HEIGHT+2*EPOCH_LENGTH)
+        assert_equal(ret['ceasingHeight'], MINIMAL_SC_HEIGHT+2*EPOCH_LENGTH+EPOCH_LENGTH/5) 
+        assert_equal(ret['endEpochHeight'], MINIMAL_SC_HEIGHT+2*EPOCH_LENGTH)
         assert_equal(ret['epoch'], 1)
         print "#### chain height=", self.nodes[0].getblockcount()
         print
@@ -170,11 +170,11 @@ class sc_cert_ceasing_sg(BitcoinTestFramework):
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
 
         ret = self.nodes[0].getscinfo(scid, False, False)['items'][0]
-        print "ceasing height   =", ret['ceasing height']
-        print "end epoch height =", ret['end epoch height']
+        print "ceasingHeight   =", ret['ceasingHeight']
+        print "endEpochHeight =", ret['endEpochHeight']
         print "epoch number     =", ret['epoch']
-        assert_equal(ret['ceasing height'], MINIMAL_SC_HEIGHT+3*EPOCH_LENGTH+EPOCH_LENGTH/5) 
-        assert_equal(ret['end epoch height'], MINIMAL_SC_HEIGHT+3*EPOCH_LENGTH)
+        assert_equal(ret['ceasingHeight'], MINIMAL_SC_HEIGHT+3*EPOCH_LENGTH+EPOCH_LENGTH/5) 
+        assert_equal(ret['endEpochHeight'], MINIMAL_SC_HEIGHT+3*EPOCH_LENGTH)
         assert_equal(ret['epoch'], 2)
         print "#### chain height=", self.nodes[0].getblockcount()
         print
@@ -198,8 +198,8 @@ class sc_cert_ceasing_sg(BitcoinTestFramework):
         self.sync_all()
 
         ret = self.nodes[0].getscinfo(scid, False, False)['items'][0]
-        print "ceasing height   =", ret['ceasing height']
-        print "end epoch height =", ret['end epoch height']
+        print "ceasingHeight   =", ret['ceasingHeight']
+        print "endEpochHeight =", ret['endEpochHeight']
         print "epoch number     =", ret['epoch']
         print "#### chain height=", self.nodes[0].getblockcount()
         print

--- a/qa/rpc-tests/sc_cert_ceasing_split.py
+++ b/qa/rpc-tests/sc_cert_ceasing_split.py
@@ -133,7 +133,7 @@ class CeasingSplitTest(BitcoinTestFramework):
 
         mark_logs("\n==> certificate for epoch {} {}l".format(epoch_number, cert), self.nodes, DEBUG_MODE)
 
-        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasing height']
+        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
         numbBlocks = ceas_height - self.nodes[0].getblockcount() + sc_epoch_len - 1
 
         mark_logs("\nNode0 generates {} block reaching the sg for the next epoch".format(numbBlocks), self.nodes, DEBUG_MODE)
@@ -142,9 +142,9 @@ class CeasingSplitTest(BitcoinTestFramework):
 
         cur_h = self.nodes[0].getblockcount()
         ret=self.nodes[0].getscinfo(scid, True, False)['items'][0]
-        cr_height=ret['created at block height']
-        ceas_h = ret['ceasing height']
-        mark_logs("epoch number={}, current height={}, creation height={}, ceasing height={}, epoch_len={}"
+        cr_height=ret['createdAtBlockHeight']
+        ceas_h = ret['ceasingHeight']
+        mark_logs("epoch number={}, current height={}, creation height={}, ceasingHeight={}, epoch_len={}"
             .format(epoch_number, cur_h, cr_height, ceas_h, sc_epoch_len), self.nodes, DEBUG_MODE)
         print
 

--- a/qa/rpc-tests/sc_cert_change.py
+++ b/qa/rpc-tests/sc_cert_change.py
@@ -194,7 +194,7 @@ class sc_cert_change(BitcoinTestFramework):
             mark_logs("Get transaction failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
             assert(False)
 
-        # node3 has also immature amounts deriving from the latest certificate whose change has been used for the funds just received 
+        # node3 has also immatureAmounts deriving from the latest certificate whose change has been used for the funds just received 
         assert_equal(res['amount'], 0.0)
         assert_equal(res['txid'], cert_ep2)
         # immature BT amounts are not displayed by default
@@ -211,7 +211,7 @@ class sc_cert_change(BitcoinTestFramework):
             mark_logs("Get transaction failed with reason {}".format(errorString), self.nodes, DEBUG_MODE)
             assert(False)
 
-        # node3 has also immature amounts deriving from the latest certificate whose change has been used for the funds just received 
+        # node3 has also immatureAmounts deriving from the latest certificate whose change has been used for the funds just received 
         assert_equal(res['amount'], 0.0)
         assert_equal(res['txid'], cert_ep2)
         # immature BT amounts must be displayed now

--- a/qa/rpc-tests/sc_cert_epoch.py
+++ b/qa/rpc-tests/sc_cert_epoch.py
@@ -117,7 +117,7 @@ class sc_cert_epoch(BitcoinTestFramework):
         self.sync_all()
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], fwt_amount_immature_at_epoch)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], fwt_amount_immature_at_epoch)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
         mark_logs("epoch_number = {}, epoch_cum_tree_hash = {}".format(epoch_number, epoch_cum_tree_hash), self.nodes, DEBUG_MODE)
@@ -276,7 +276,7 @@ class sc_cert_epoch(BitcoinTestFramework):
         mark_logs("Node0 generating 4 block to show bwd has disappeared from history", self.nodes, DEBUG_MODE)
         blocks.extend(self.nodes[0].generate(4))
         sc_post_regeneration = self.nodes[0].getscinfo(scid)['items'][0]
-        assert_equal(sc_post_regeneration["last certificate epoch"], Decimal(0))
+        assert_equal(sc_post_regeneration["lastCertificateEpoch"], Decimal(0))
         assert_equal(sc_post_regeneration["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
 
         mark_logs("Node0 generating 6 block to have longest chain and cause reorg on other nodes", self.nodes, DEBUG_MODE)
@@ -288,7 +288,7 @@ class sc_cert_epoch(BitcoinTestFramework):
         for idx, node in enumerate(self.nodes):
             mark_logs("Checking Node{} ScInfos".format(idx), self.nodes, DEBUG_MODE)
             sc_post_regeneration = node.getscinfo(scid)['items'][0]
-            assert_equal(sc_post_regeneration["last certificate epoch"], Decimal(0))
+            assert_equal(sc_post_regeneration["lastCertificateEpoch"], Decimal(0))
             assert_equal(sc_post_regeneration["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
             assert(cert_epoch_1 not in node.getrawmempool())
             assert(speding_bwd_tx not in node.getrawmempool())
@@ -304,7 +304,7 @@ class sc_cert_epoch(BitcoinTestFramework):
         for idx, node in enumerate(self.nodes):
             mark_logs("Checking Node{} after restart".format(idx), self.nodes, DEBUG_MODE)
             sc_post_regeneration = node.getscinfo(scid)['items'][0]
-            assert_equal(sc_post_regeneration["last certificate epoch"], Decimal(0))
+            assert_equal(sc_post_regeneration["lastCertificateEpoch"], Decimal(0))
             assert_equal(sc_post_regeneration["balance"], creation_amount + fwt_amount + fwt_amount_immature_at_epoch - bwt_amount)
             assert(cert_epoch_1 not in node.getrawmempool())
             assert(speding_bwd_tx not in node.getrawmempool())

--- a/qa/rpc-tests/sc_cert_getblocktemplate.py
+++ b/qa/rpc-tests/sc_cert_getblocktemplate.py
@@ -89,7 +89,7 @@ class sc_cert_base(BitcoinTestFramework):
 
         cur_h = self.nodes[0].getblockcount()
         ret = self.nodes[0].getscinfo(scid, True, False)['items'][0]
-        ceas_h = ret['ceasing height']
+        ceas_h = ret['ceasingHeight']
         ceas_limit_delta = ceas_h - cur_h - 1
 
         mark_logs("Node0 generating {} blocks reaching the third to last block before the SC ceasing".format(ceas_limit_delta), self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_cert_invalidate.py
+++ b/qa/rpc-tests/sc_cert_invalidate.py
@@ -194,7 +194,7 @@ class sc_cert_invalidate(BitcoinTestFramework):
         self.refresh_sidechain(sc_info, scid)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
-        sc_creating_height = self.nodes[0].getscinfo(scid)['items'][0]['created at block height']
+        sc_creating_height = self.nodes[0].getscinfo(scid)['items'][0]['createdAtBlockHeight']
         epoch_block_hash = self.nodes[0].getblockhash(sc_creating_height - 1 + ((epoch_number + 1) * EPOCH_LENGTH))
 
         mark_logs("epoch_number = {}, epoch_cum_tree_hash = {}".format(epoch_number, epoch_cum_tree_hash), self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_cert_maturity.py
+++ b/qa/rpc-tests/sc_cert_maturity.py
@@ -254,7 +254,7 @@ class sc_cert_maturity(BitcoinTestFramework):
         self.nodes[0].generate(4)
         self.sync_all()
         print "Height=", self.nodes[0].getblockcount()
-        print "Ceasing at h =", self.nodes[0].getscinfo("*")['items'][0]['ceasing height']
+        print "Ceasing at h =", self.nodes[0].getscinfo("*")['items'][0]['ceasingHeight']
         print "State =", self.nodes[0].getscinfo("*")['items'][0]['state']
         assert_equal(self.nodes[0].getscinfo("*")['items'][0]['state'], "ALIVE")
 

--- a/qa/rpc-tests/sc_cert_memcleanup_split.py
+++ b/qa/rpc-tests/sc_cert_memcleanup_split.py
@@ -131,7 +131,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
 
         mark_logs("\n==> certificate for epoch {} {}l".format(epoch_number, cert), self.nodes, DEBUG_MODE)
 
-        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasing height']
+        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
         numbBlocks = ceas_height - self.nodes[0].getblockcount() + sc_epoch_len - 1
         print "Node0 Chain h = ", self.nodes[0].getblockcount()
 

--- a/qa/rpc-tests/sc_cert_quality_wallet.py
+++ b/qa/rpc-tests/sc_cert_quality_wallet.py
@@ -127,9 +127,9 @@ class sc_cert_quality_wallet(BitcoinTestFramework):
 
         scinfo = self.nodes[2].getscinfo(scid, False, False)
         assert_equal(bwt_amount_1, creation_amount - scinfo['items'][0]['balance'])
-        assert_equal(bwt_amount_1, scinfo['items'][0]['last certificate amount'])
-        assert_equal(cert_epoch_0_1, scinfo['items'][0]['last certificate hash'])
-        assert_equal(quality, scinfo['items'][0]['last certificate quality'])
+        assert_equal(bwt_amount_1, scinfo['items'][0]['lastCertificateAmount'])
+        assert_equal(cert_epoch_0_1, scinfo['items'][0]['lastCertificateHash'])
+        assert_equal(quality, scinfo['items'][0]['lastCertificateQuality'])
 
         winfo = self.nodes[2].getwalletinfo()
         assert_equal(Decimal("0"), winfo['balance'])
@@ -159,9 +159,9 @@ class sc_cert_quality_wallet(BitcoinTestFramework):
 
         scinfo = self.nodes[2].getscinfo(scid, False, False)
         assert_equal(bwt_amount_2, creation_amount - scinfo['items'][0]['balance'])
-        assert_equal(bwt_amount_2, scinfo['items'][0]['last certificate amount'])
-        assert_equal(cert_epoch_0_2, scinfo['items'][0]['last certificate hash'])
-        assert_equal(quality, scinfo['items'][0]['last certificate quality'])
+        assert_equal(bwt_amount_2, scinfo['items'][0]['lastCertificateAmount'])
+        assert_equal(cert_epoch_0_2, scinfo['items'][0]['lastCertificateHash'])
+        assert_equal(quality, scinfo['items'][0]['lastCertificateQuality'])
 
         winfo = self.nodes[2].getwalletinfo()
         assert_equal(Decimal("0"), winfo['balance'])
@@ -245,9 +245,9 @@ class sc_cert_quality_wallet(BitcoinTestFramework):
 
         scinfo = self.nodes[2].getscinfo(scid, False, False)
         assert_equal(bwt_amount_4 + bwt_amount_2, creation_amount - scinfo['items'][0]['balance'])
-        assert_equal(bwt_amount_4, scinfo['items'][0]['last certificate amount'])
-        assert_equal(cert_epoch_1_4, scinfo['items'][0]['last certificate hash'])
-        assert_equal(quality_h, scinfo['items'][0]['last certificate quality'])
+        assert_equal(bwt_amount_4, scinfo['items'][0]['lastCertificateAmount'])
+        assert_equal(cert_epoch_1_4, scinfo['items'][0]['lastCertificateHash'])
+        assert_equal(quality_h, scinfo['items'][0]['lastCertificateQuality'])
 
         winfo = self.nodes[2].getwalletinfo()
         assert_equal(bwt_amount_2, winfo['balance'])
@@ -280,9 +280,9 @@ class sc_cert_quality_wallet(BitcoinTestFramework):
 
         scinfo = self.nodes[2].getscinfo(scid, False, False)
         assert_equal(bwt_amount_5 + bwt_amount_4 + bwt_amount_2, creation_amount - scinfo['items'][0]['balance'])
-        assert_equal(bwt_amount_5, scinfo['items'][0]['last certificate amount'])
-        assert_equal(cert_epoch_2_5, scinfo['items'][0]['last certificate hash'])
-        assert_equal(quality, scinfo['items'][0]['last certificate quality'])
+        assert_equal(bwt_amount_5, scinfo['items'][0]['lastCertificateAmount'])
+        assert_equal(cert_epoch_2_5, scinfo['items'][0]['lastCertificateHash'])
+        assert_equal(quality, scinfo['items'][0]['lastCertificateQuality'])
 
         winfo = self.nodes[2].getwalletinfo()
         assert_equal(bwt_amount_2 + bwt_amount_4, winfo['balance'])
@@ -303,9 +303,9 @@ class sc_cert_quality_wallet(BitcoinTestFramework):
 
         scinfo = self.nodes[2].getscinfo(scid, False, False)
         assert_equal(bwt_amount_5 + bwt_amount_4 + bwt_amount_2, creation_amount - scinfo['items'][0]['balance'])
-        assert_equal(bwt_amount_5, scinfo['items'][0]['last certificate amount'])
-        assert_equal(cert_epoch_2_5, scinfo['items'][0]['last certificate hash'])
-        assert_equal(quality, scinfo['items'][0]['last certificate quality'])
+        assert_equal(bwt_amount_5, scinfo['items'][0]['lastCertificateAmount'])
+        assert_equal(cert_epoch_2_5, scinfo['items'][0]['lastCertificateHash'])
+        assert_equal(quality, scinfo['items'][0]['lastCertificateQuality'])
 
         winfo = self.nodes[2].getwalletinfo()
         assert_equal(bwt_amount_2 + bwt_amount_4, winfo['balance'])

--- a/qa/rpc-tests/sc_create.py
+++ b/qa/rpc-tests/sc_create.py
@@ -354,7 +354,7 @@ class SCCreateTest(BitcoinTestFramework):
 
         dump_sc_info_record(self.nodes[2].getscinfo(scid)['items'][0], 2, DEBUG_MODE)
         mark_logs("Check that %f coins will be mature at h=%d" % (creation_amount, curh + 2), self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immatureAmounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + SC_COINS_MAT:
                 assert_equal(entry["amount"], creation_amount)
@@ -394,7 +394,7 @@ class SCCreateTest(BitcoinTestFramework):
         count = 0
         mark_logs("Check that %f coins will be mature at h=%d" % (creation_amount, curh + 1), self.nodes, DEBUG_MODE)
         mark_logs("Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 2), self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immatureAmounts"]
         for entry in ia:
             count += 1
             if entry["maturityHeight"] == curh + SC_COINS_MAT:
@@ -414,7 +414,7 @@ class SCCreateTest(BitcoinTestFramework):
         dump_sc_info_record(self.nodes[2].getscinfo(scid)['items'][0], 2, DEBUG_MODE)
         count = 0
         mark_logs("Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 1), self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immatureAmounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + SC_COINS_MAT - 1:
                 assert_equal(entry["amount"], fwt_amount_many + fwt_amount_1)
@@ -432,7 +432,7 @@ class SCCreateTest(BitcoinTestFramework):
         pprint.pprint(scinfo)
 
         mark_logs("Check that there are no immature coins", self.nodes, DEBUG_MODE)
-        ia = self.nodes[2].getscinfo(scid)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid)['items'][0]["immatureAmounts"]
         assert_equal(len(ia), 0)
 
         mark_logs("Checking blockindex persistance stopping and restarting nodes", self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_create_2.py
+++ b/qa/rpc-tests/sc_create_2.py
@@ -573,7 +573,7 @@ class SCCreateTest(BitcoinTestFramework):
         if DEBUG_MODE:
             pprint.pprint(scinfo0)
 
-        assert_equal(tot_many, scinfo0['immature amounts'][0]['amount'])
+        assert_equal(tot_many, scinfo0['immatureAmounts'][0]['amount'])
         bal_t1 = self.nodes[1].getbalance()
         assert_equal(bal_t0, bal_t1 + tot_many + fee)
 

--- a/qa/rpc-tests/sc_csw_memcleanup_split.py
+++ b/qa/rpc-tests/sc_csw_memcleanup_split.py
@@ -133,7 +133,7 @@ class CertMempoolCleanupSplit(BitcoinTestFramework):
 
         mark_logs("\n==> certificate for epoch {} {}l".format(epoch_number, cert), self.nodes, DEBUG_MODE)
 
-        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasing height']
+        ceas_height = self.nodes[0].getscinfo(scid, False, False)['items'][0]['ceasingHeight']
         numbBlocks = ceas_height - self.nodes[0].getblockcount() + sc_epoch_len - 1
         print "Node0 Chain h = ", self.nodes[0].getblockcount()
 

--- a/qa/rpc-tests/sc_csw_nullifier.py
+++ b/qa/rpc-tests/sc_csw_nullifier.py
@@ -599,7 +599,7 @@ class CswNullifierTest(BitcoinTestFramework):
 
         ret = self.nodes[0].getscinfo(scid2, False, True)['items'][0]
         assert_equal(ret['state'], "CEASED")
-        assert_equal(ret['last certificate epoch'], 1)
+        assert_equal(ret['lastCertificateEpoch'], 1)
 
         try:
             assert_true(self.nodes[1].getactivecertdatahash(scid2)['certDataHash'])

--- a/qa/rpc-tests/sc_ft_and_mbtr_fees.py
+++ b/qa/rpc-tests/sc_ft_and_mbtr_fees.py
@@ -184,8 +184,8 @@ class SCFtAndMbtrFeesTest(BitcoinTestFramework):
         assert_equal(scinfo0, scinfo1)
 
         mark_logs("Verify that sidechain configuration is as expected", self.nodes, DEBUG_MODE)
-        assert_equal(scinfo0['last ftScFee'], ftFee)
-        assert_equal(scinfo0['last mbtrScFee'], mbtrFee)
+        assert_equal(scinfo0['lastFtScFee'], ftFee)
+        assert_equal(scinfo0['lastMbtrScFee'], mbtrFee)
         assert_equal(scinfo0['mbtrRequestDataLength'], mbtrRequestDataLength)
 
         self.sync_all()
@@ -345,16 +345,16 @@ class SCFtAndMbtrFeesTest(BitcoinTestFramework):
 
         # Check that Node 1 has updated the sidechain fees
         mark_logs("\nCheck that node 1 has updated the sidechain fees", self.nodes, DEBUG_MODE)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['past ftScFee'], ftFee)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['last ftScFee'], newFtFee)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['past mbtrScFee'], mbtrFee)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['last mbtrScFee'], newMbtrFee)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['pastFtScFee'], ftFee)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['lastFtScFee'], newFtFee)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['pastMbtrScFee'], mbtrFee)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['lastMbtrScFee'], newMbtrFee)
 
         # Check that Node 0 still has the old fees (since it is not connected to node 1)
         mark_logs("\nCheck that node 0 has not updated the sidechain fees", self.nodes, DEBUG_MODE)
         tmp = self.nodes[0].getscinfo(scid)['items'][0]
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['last ftScFee'], ftFee)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['last mbtrScFee'], mbtrFee)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['lastFtScFee'], ftFee)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['lastMbtrScFee'], mbtrFee)
 
 
         # ---------------------------------------------------------------------------------------

--- a/qa/rpc-tests/sc_fwd_maturity.py
+++ b/qa/rpc-tests/sc_fwd_maturity.py
@@ -111,7 +111,7 @@ class sc_fwd_maturity(BitcoinTestFramework):
         print "Current height: ", curh
         dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 2:
                 assert_equal(entry["amount"], creation_amount)
@@ -170,7 +170,7 @@ class sc_fwd_maturity(BitcoinTestFramework):
         count = 0
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 1)
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         for entry in ia:
             count += 1
             if entry["maturityHeight"] == curh + 2:
@@ -200,7 +200,7 @@ class sc_fwd_maturity(BitcoinTestFramework):
         dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 1)
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 1:
                 assert_equal(entry["amount"], fwt_amount_many + fwt_amount_1)
@@ -220,7 +220,7 @@ class sc_fwd_maturity(BitcoinTestFramework):
         dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that there are no immature coins"
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         assert_equal(len(ia), 0)
         print "...OK"
         print
@@ -239,7 +239,7 @@ class sc_fwd_maturity(BitcoinTestFramework):
         dump_sc_info_record(self.nodes[2].getscinfo(scid_1)['items'][0], 2)
         count = 0
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 1)
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 1:
                 assert_equal(entry["amount"], fwt_amount_many + fwt_amount_1)
@@ -264,7 +264,7 @@ class sc_fwd_maturity(BitcoinTestFramework):
         count = 0
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 1)
         print "Check that %f coins will be mature at h=%d" % (fwt_amount_many + fwt_amount_1, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         for entry in ia:
             count += 1
             if entry["maturityHeight"] == curh + 2:
@@ -289,14 +289,14 @@ class sc_fwd_maturity(BitcoinTestFramework):
         print "Current height: ", curh
         dump_sc_info(self.nodes, NUMB_OF_NODES)
         print "Check that %f coins will be mature at h=%d" % (creation_amount, curh + 2)
-        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immature amounts"]
+        ia = self.nodes[2].getscinfo(scid_1)['items'][0]["immatureAmounts"]
         for entry in ia:
             if entry["maturityHeight"] == curh + 2:
                 assert_equal(entry["amount"], creation_amount)
             print "...OK"
             print
 
-        creating_tx = self.nodes[2].getscinfo(scid_1)['items'][0]['creating tx hash']
+        creating_tx = self.nodes[2].getscinfo(scid_1)['items'][0]['creatingTxHash']
         
         mark_logs("\nNode 2 invalidates best block", self.nodes, DEBUG_MODE)
         try:
@@ -308,8 +308,8 @@ class sc_fwd_maturity(BitcoinTestFramework):
         print "Current height: ", self.nodes[2].getblockcount()
         print "Checking that sc info on Node2 is not available in blockchain (just in mempool)..."
         scinfo = self.nodes[2].getscinfo(scid_1)['items'][0]
-        assert_false('creating tx hash' in scinfo)
-        assert_true(scinfo['unconf creating tx hash'], creating_tx)
+        assert_false('creatingTxHash' in scinfo)
+        assert_true(scinfo['unconfCreatingTxHash'], creating_tx)
 
         print "...OK"
         print

--- a/qa/rpc-tests/sc_getscinfo.py
+++ b/qa/rpc-tests/sc_getscinfo.py
@@ -129,7 +129,7 @@ class sc_getscinfo(BitcoinTestFramework):
         # check all of them have right block creation hash which is part of verbose output
         # and fill the ordered scids lists
         for item in sc_info_all['items']:
-            assert_equal(item['created at block height'], sc_creating_height)
+            assert_equal(item['createdAtBlockHeight'], sc_creating_height)
             scids_all.append(item['scid'])
             if item['state'] == "ALIVE":
                 scids_alive.append(item['scid'])
@@ -157,7 +157,7 @@ class sc_getscinfo(BitcoinTestFramework):
         count = 0
         for item in sc_info['items']:
             try:
-                assert_equal(item['created at block height'], sc_creating_height)
+                assert_equal(item['createdAtBlockHeight'], sc_creating_height)
                 assert_true(False)
             except Exception, e:
                 # it is ok, we expected it
@@ -179,7 +179,7 @@ class sc_getscinfo(BitcoinTestFramework):
 
         count = from_par
         for item in sc_info['items']:
-            assert_equal(item['created at block height'], sc_creating_height)
+            assert_equal(item['createdAtBlockHeight'], sc_creating_height)
             assert_equal(scids_all[count], item['scid'])
             count += 1
 
@@ -293,8 +293,14 @@ class sc_getscinfo(BitcoinTestFramework):
         self.sync_all()
 
         result = self.nodes[0].getscinfo(scid_0)
-        assert_equal(cert_1_epoch_0, result['items'][0]['unconf top quality certificate hash'])
-        assert_equal(quality, result['items'][0]['unconf top quality certificate quality'])
+        assert_equal(cert_1_epoch_0, result['items'][0]['unconfTopQualityCertificateHash'])
+        assert_equal(quality, result['items'][0]['unconfTopQualityCertificateQuality'])
+
+        elen = item['withdrawalEpochLength']
+        wlen = item['certSubmissionWindowLength']
+        wlen_calc = max(2, int(elen/5))
+        assert_equal(wlen, wlen_calc)
+
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/sc_proof_verifier_low_priority_threads.py
+++ b/qa/rpc-tests/sc_proof_verifier_low_priority_threads.py
@@ -45,7 +45,7 @@ class sc_proof_verifier_low_priority_threads(BitcoinTestFramework):
                                 extra_args=['-debug=py', '-debug=sc', '-debug=mempool',
                                     '-debug=net', '-debug=cert', '-debug=zendoo_mc_cryptolib',
                                     '-scproofqueuesize=0', '-logtimemicros=1', '-rpcservertimeout=10'],
-                                timewait=10)]  # 10 seconds of timeout
+                                timewait=30)]  # 30 seconds of timeout
 
     def run_test(self):
 
@@ -88,7 +88,7 @@ class sc_proof_verifier_low_priority_threads(BitcoinTestFramework):
         self.nodes[0].generate(1)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to Sc
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -101,14 +101,14 @@ class sc_proof_verifier_low_priority_threads(BitcoinTestFramework):
         self.nodes[0].generate(1)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][1]['amount'], fwt_amount)
 
         nblocks = EPOCH_LENGTH - 2
         mark_logs("Node0 generating {} more blocks to achieve end of withdrawal epoch".format(nblocks), self.nodes, DEBUG_MODE)
         self.nodes[0].generate(nblocks)
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
         mark_logs("epoch_number = {}, epoch_cum_tree_hash = {}".format(epoch_number, epoch_cum_tree_hash), self.nodes, DEBUG_MODE)

--- a/qa/rpc-tests/sc_quality_blockchain.py
+++ b/qa/rpc-tests/sc_quality_blockchain.py
@@ -107,7 +107,7 @@ class quality_blockchain(BitcoinTestFramework):
         assert_equal(bal_before_sc_creation, bal_after_sc_creation + creation_amount - fee_sc_creation)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to Sc
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -129,14 +129,14 @@ class quality_blockchain(BitcoinTestFramework):
         assert_equal(bal_before_fwd_tx, bal_after_fwd_tx + fwt_amount - fee_fwt - Decimal(MINER_REWARD_POST_H200))
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][1]['amount'], fwt_amount)
 
         mark_logs("Node0 generating {} more blocks to achieve end of withdrawal epoch".format(EPOCH_LENGTH - 2), self.nodes, DEBUG_MODE)
         self.nodes[0].generate(EPOCH_LENGTH - 2)
         self.sync_all()
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
 

--- a/qa/rpc-tests/sc_quality_mempool.py
+++ b/qa/rpc-tests/sc_quality_mempool.py
@@ -121,7 +121,7 @@ class quality_mempool(BitcoinTestFramework):
         assert_equal(bal_before_sc_creation, bal_after_sc_creation + creation_amount + creation_amount - fee_sc_creation_1 - fee_sc_creation_2)
 
         assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to SC 1
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -155,14 +155,14 @@ class quality_mempool(BitcoinTestFramework):
         assert_equal(bal_before_fwd_tx, bal_after_fwd_tx + fwt_amount - fee_fwt - Decimal(MINER_REWARD_POST_H200))
 
         assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['immatureAmounts'][1]['amount'], fwt_amount)
 
         mark_logs("Node0 generating more blocks to achieve end of withdrawal epoch", self.nodes, DEBUG_MODE)
         self.nodes[0].generate(EPOCH_LENGTH - 3)
         self.sync_all()
         assert_equal(self.nodes[0].getscinfo(scid_1)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid_1)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid_1)['items'][0]['immatureAmounts']), 0)
 
         epoch_number_1, epoch_cum_tree_hash_1 = get_epoch_data(scid_1, self.nodes[0], EPOCH_LENGTH)
 

--- a/qa/rpc-tests/sc_quality_nodes.py
+++ b/qa/rpc-tests/sc_quality_nodes.py
@@ -115,7 +115,7 @@ class quality_nodes(BitcoinTestFramework):
         #assert_equal(bal_before_sc_creation, bal_after_sc_creation + creation_amount + creation_amount - fee_sc_creation - fee_sc_creation)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to SC 1
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -137,8 +137,8 @@ class quality_nodes(BitcoinTestFramework):
         assert_equal(bal_before_fwd_tx, bal_after_fwd_tx + fwt_amount - fee_fwt - Decimal(MINER_REWARD_POST_H200))
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][1]['amount'], fwt_amount)
 
 
         bal_after_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -152,7 +152,7 @@ class quality_nodes(BitcoinTestFramework):
         mark_logs("Chain height={}".format(h), self.nodes, DEBUG_MODE)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
 

--- a/qa/rpc-tests/sc_quality_voiding.py
+++ b/qa/rpc-tests/sc_quality_voiding.py
@@ -103,7 +103,7 @@ class quality_voiding(BitcoinTestFramework):
         assert_equal(bal_before_sc_creation, bal_after_sc_creation + creation_amount - fee_sc_creation)
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
 
         # Fwd Transfer to Sc
         bal_before_fwd_tx = self.nodes[0].getbalance("", 0)
@@ -125,14 +125,14 @@ class quality_voiding(BitcoinTestFramework):
         assert_equal(bal_before_fwd_tx, bal_after_fwd_tx + fwt_amount - fee_fwt - Decimal(MINER_REWARD_POST_H200))
 
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], Decimal(0))
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][0]['amount'], creation_amount)
-        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts'][1]['amount'], fwt_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][0]['amount'], creation_amount)
+        assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts'][1]['amount'], fwt_amount)
 
         mark_logs("Node0 generating 3 more blocks to achieve end of withdrawal epoch", self.nodes, DEBUG_MODE)
         self.nodes[0].generate(EPOCH_LENGTH - 2)
         self.sync_all()
         assert_equal(self.nodes[0].getscinfo(scid)['items'][0]['balance'], creation_amount + fwt_amount) # Sc balance has matured
-        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immature amounts']), 0)
+        assert_equal(len(self.nodes[0].getscinfo(scid)['items'][0]['immatureAmounts']), 0)
 
         epoch_number, epoch_cum_tree_hash = get_epoch_data(scid, self.nodes[0], EPOCH_LENGTH)
 

--- a/qa/rpc-tests/sc_split.py
+++ b/qa/rpc-tests/sc_split.py
@@ -158,8 +158,8 @@ class ScSplitTest(BitcoinTestFramework):
         assert_equal(scinfoNode0, scinfoNode1)
         
         assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["balance"], creation_amount + fwt_amount_1 + fwt_amount_2)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["created at block height"], ownerBlockHeight)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["creating tx hash"], creating_tx)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["createdAtBlockHeight"], ownerBlockHeight)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["creatingTxHash"], creating_tx)
         assert_equal(0, self.nodes[2].getscinfo(scid)['totalItems'])
 
         # ---------------------------------------------------------------------------------------
@@ -175,8 +175,8 @@ class ScSplitTest(BitcoinTestFramework):
 
         mark_logs("\nChecking that sc info on Node1 are not available anymore in blockchain since tx has been reverted...", self.nodes, DEBUG_MODE)
         ret = self.nodes[1].getscinfo(scid)['items'][0]
-        assert_false('creating tx hash' in ret)
-        assert_true(ret['unconf creating tx hash'], creating_tx)
+        assert_false('creatingTxHash' in ret)
+        assert_true(ret['unconfCreatingTxHash'], creating_tx)
 
         # Check the mempools of every nodes
         mark_logs("\nChecking mempools...", self.nodes, DEBUG_MODE)
@@ -217,8 +217,8 @@ class ScSplitTest(BitcoinTestFramework):
         assert_equal(scinfoNode0, scinfoNode1)
         assert_equal(scinfoNode0, scinfoNode2)
         assert_equal(self.nodes[2].getscinfo(scid)['items'][0]["balance"], creation_amount + fwt_amount_1 + fwt_amount_2)
-        assert_equal(self.nodes[2].getscinfo(scid)['items'][0]["created at block height"], secondOwnerBlockHeight)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["creating tx hash"], creating_tx)
+        assert_equal(self.nodes[2].getscinfo(scid)['items'][0]["createdAtBlockHeight"], secondOwnerBlockHeight)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]["creatingTxHash"], creating_tx)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/sc_stale_ft_and_mbtr.py
+++ b/qa/rpc-tests/sc_stale_ft_and_mbtr.py
@@ -110,9 +110,9 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
             f_max = Decimal('0.0')
             for i in scFeesList:
                 f_min = min(f_min, i['forwardTxScFee'])
-                m_min = min(m_min, i['   mbtrTxScFee'])
+                m_min = min(m_min, i['mbtrTxScFee'])
                 f_max = max(f_max, i['forwardTxScFee'])
-                m_max = max(m_max, i['   mbtrTxScFee'])
+                m_max = max(m_max, i['mbtrTxScFee'])
             return f_min, m_min, f_max, m_max
 
         '''
@@ -307,7 +307,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         assert_true(txFT in self.nodes[0].getrawmempool(True))
         assert_true(txMbtr in self.nodes[0].getrawmempool(True))
 
-        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['sc fees']
+        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['scFees']
         f_min, m_min, f_max, m_max = get_sc_fee_min_max_value(scFeesList)
         assert_equal(f_min, FT_SC_FEES[0])
         assert_equal(m_min, MBTR_SC_FEES[0])
@@ -347,7 +347,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         assert_true(txFT in self.nodes[0].getrawmempool(True))
         assert_true(txMbtr in self.nodes[0].getrawmempool(True))
 
-        assert_equal(scFeesList, self.nodes[0].getscinfo(scid)['items'][0]['sc fees'])
+        assert_equal(scFeesList, self.nodes[0].getscinfo(scid)['items'][0]['scFees'])
 
         #------------------------------------------------------------------------------------------------
         # flood the mempool with non-free and hi-prio txes so that next blocks (with small max size) will
@@ -381,7 +381,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         self.nodes[1].generate(1)
         self.sync_all()
 
-        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['sc fees']
+        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['scFees']
         f_min, m_min, f_max, m_max = get_sc_fee_min_max_value(scFeesList)
         assert_equal(f_min, FT_SC_FEES[0])
         assert_equal(m_min, MBTR_SC_FEES[0])
@@ -413,7 +413,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         bl = self.nodes[0].generate(1)[-1]
         self.sync_all()
 
-        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['sc fees']
+        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['scFees']
         f_min, m_min, f_max, m_max = get_sc_fee_min_max_value(scFeesList)
         assert_equal(f_min, FT_SC_FEES[3])
         assert_equal(m_min, MBTR_SC_FEES[3])
@@ -441,7 +441,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         bbh = self.nodes[0].getbestblockhash()
         assert_equal(bl, bbh)
 
-        scFeesList2 = self.nodes[0].getscinfo(scid)['items'][0]['sc fees']
+        scFeesList2 = self.nodes[0].getscinfo(scid)['items'][0]['scFees']
         assert_equal(scFeesList, scFeesList2)
 
         ftScFee   = FT_SC_FEES[6]
@@ -507,7 +507,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         self.nodes[1].generate(1)
         self.sync_all()
 
-        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['sc fees']
+        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['scFees']
         f_min, m_min, f_max, m_max = get_sc_fee_min_max_value(scFeesList)
         assert_equal(f_min, FT_SC_FEES[4])
         assert_equal(m_min, MBTR_SC_FEES[4])
@@ -538,7 +538,7 @@ class SCStaleFtAndMbtrTest(BitcoinTestFramework):
         bl = self.nodes[3].generate(1)[-1]
         self.sync_all()
 
-        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['sc fees']
+        scFeesList = self.nodes[0].getscinfo(scid)['items'][0]['scFees']
         f_min, m_min, f_max, m_max = get_sc_fee_min_max_value(scFeesList)
         assert_equal(f_min, FT_SC_FEES[5])
         assert_equal(m_min, MBTR_SC_FEES[5])

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -511,9 +511,9 @@ def dump_sc_info_record(info, i, debug=0):
     if debug == 0:
         return
     print "  Node %d - balance: %f" % (i, info["balance"])
-    print "    created at block: %s (%d)" % (info["created at block height"], info["created at block height"])
-    print "    created in tx:    %s" % info["creating tx hash"]
-    print "    immature amounts: %s" % info["immature amounts"]
+    print "    created at block: %s (%d)" % (info["createdAtBlockHeight"], info["createdAtBlockHeight"])
+    print "    created in tx:    %s" % info["creatingTxHash"]
+    print "    immatureAmounts: %s" % info["immatureAmounts"]
 
 def dump_sc_info(nodes,nNodes,scId="",debug=0):
     if debug == 0:
@@ -540,14 +540,14 @@ def mark_logs(msg,nodes,debug=0):
         node.dbg_log(msg)
 
 def get_end_epoch_height(scid, node, epochLen):
-    sc_creating_height = node.getscinfo(scid)['items'][0]['created at block height']
+    sc_creating_height = node.getscinfo(scid)['items'][0]['createdAtBlockHeight']
     current_height = node.getblockcount()
     epoch_number = (current_height - sc_creating_height + 1) // epochLen - 1
     end_epoch_height = sc_creating_height - 1 + ((epoch_number + 1) * epochLen)
     return end_epoch_height
 
 def get_epoch_data(scid, node, epochLen):
-    sc_creating_height = node.getscinfo(scid)['items'][0]['created at block height']
+    sc_creating_height = node.getscinfo(scid)['items'][0]['createdAtBlockHeight']
     current_height = node.getblockcount()
     epoch_number = (current_height - sc_creating_height + 1) // epochLen - 1
     end_epoch_block_hash = node.getblockhash(sc_creating_height - 1 + ((epoch_number + 1) * epochLen))

--- a/qa/rpc-tests/ws_messages.py
+++ b/qa/rpc-tests/ws_messages.py
@@ -205,8 +205,8 @@ class ws_messages(BitcoinTestFramework):
         decoded_coinbase = self.nodes[2].getrawtransaction(coinbase, 1)
         miner_quota = decoded_coinbase['vout'][0]['value']
         assert_equal((Decimal('7.5') + CERT_FEE), miner_quota)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['last ftScFee'], FT_SC_FEE)
-        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['last mbtrScFee'], MBTR_SC_FEE)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['lastFtScFee'], FT_SC_FEE)
+        assert_equal(self.nodes[1].getscinfo(scid)['items'][0]['lastMbtrScFee'], MBTR_SC_FEE)
 
         # ----------------------------------------------------------------"
         # Test get single block

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1136,7 +1136,7 @@ static void addScUnconfCcData(const uint256& scId, UniValue& sc)
             if (scId == scCrAmount.GetScId())
             {
                  UniValue o(UniValue::VOBJ);
-                 o.pushKV("unconf amount", ValueFromAmount(scCrAmount.nValue));
+                 o.pushKV("unconfAmount", ValueFromAmount(scCrAmount.nValue));
                  ia.push_back(o);
              }
         }
@@ -1150,7 +1150,7 @@ static void addScUnconfCcData(const uint256& scId, UniValue& sc)
             if (scId == fwdAmount.scId)
             {
                  UniValue o(UniValue::VOBJ);
-                 o.pushKV("unconf amount", ValueFromAmount(fwdAmount.GetScValue()));
+                 o.pushKV("unconfAmount", ValueFromAmount(fwdAmount.GetScValue()));
                  ia.push_back(o);
              }
         }
@@ -1164,14 +1164,14 @@ static void addScUnconfCcData(const uint256& scId, UniValue& sc)
             if (scId == mbtrAmount.scId)
             {
                  UniValue o(UniValue::VOBJ);
-                 o.pushKV("unconf amount", ValueFromAmount(mbtrAmount.GetScValue()));
+                 o.pushKV("unconfAmount", ValueFromAmount(mbtrAmount.GetScValue()));
                  ia.push_back(o);
              }
         }
     }
 
     if (ia.size() > 0)
-        sc.pushKV("unconf immature amounts", ia);
+        sc.pushKV("unconfImmatureAmounts", ia);
 
     // there are no info about bwt requests in sc db, therefore we do not include them neither when they are in mempool
 }
@@ -1191,28 +1191,29 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
  
         sc.pushKV("balance", ValueFromAmount(info.balance));
         sc.pushKV("epoch", currentEpoch);
-        sc.pushKV("end epoch height", info.GetEndHeightForEpoch(currentEpoch));
+        sc.pushKV("endEpochHeight", info.GetEndHeightForEpoch(currentEpoch));
         sc.pushKV("state", CSidechain::stateToString(scState));
-        sc.pushKV("ceasing height", info.GetScheduledCeasingHeight());
+        sc.pushKV("ceasingHeight", info.GetScheduledCeasingHeight());
  
         if (bVerbose)
         {
-            sc.pushKV("creating tx hash", info.creationTxHash.GetHex());
+            sc.pushKV("creatingTxHash", info.creationTxHash.GetHex());
         }
  
-        sc.pushKV("created at block height", info.creationBlockHeight);
-        sc.pushKV("last certificate epoch", info.lastTopQualityCertReferencedEpoch);
-        sc.pushKV("last certificate hash", info.lastTopQualityCertHash.GetHex());
-        sc.pushKV("last certificate quality", info.lastTopQualityCertQuality);
-        sc.pushKV("last certificate amount", ValueFromAmount(info.lastTopQualityCertBwtAmount));
+        sc.pushKV("createdAtBlockHeight", info.creationBlockHeight);
+        sc.pushKV("lastCertificateEpoch", info.lastTopQualityCertReferencedEpoch);
+        sc.pushKV("lastCertificateHash", info.lastTopQualityCertHash.GetHex());
+        sc.pushKV("lastCertificateQuality", info.lastTopQualityCertQuality);
+        sc.pushKV("lastCertificateAmount", ValueFromAmount(info.lastTopQualityCertBwtAmount));
 
         const CScCertificateView& certView = scView.GetActiveCertView(scId);
-        sc.pushKV("active ftScFee", ValueFromAmount(certView.forwardTransferScFee));
-        sc.pushKV("active mbtrScFee", ValueFromAmount(certView.mainchainBackwardTransferRequestScFee));
+        sc.pushKV("activeFtScFee", ValueFromAmount(certView.forwardTransferScFee));
+        sc.pushKV("activeMbtrScFee", ValueFromAmount(certView.mainchainBackwardTransferRequestScFee));
  
         // creation parameters
         sc.pushKV("mbtrRequestDataLength", info.fixedParams.mainchainBackwardTransferRequestDataLength);
         sc.pushKV("withdrawalEpochLength", info.fixedParams.withdrawalEpochLength);
+        sc.pushKV("certSubmissionWindowLength", info.GetCertSubmissionWindowLength());
  
         if (bVerbose)
         {
@@ -1250,10 +1251,10 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
             }
             sc.pushKV("vBitVectorCertificateFieldConfig", arrBitVectorConfig);
 
-            sc.pushKV("past ftScFee", ValueFromAmount(info.pastEpochTopQualityCertView.forwardTransferScFee));
-            sc.pushKV("past mbtrScFee", ValueFromAmount(info.pastEpochTopQualityCertView.mainchainBackwardTransferRequestScFee));
-            sc.pushKV("last ftScFee", ValueFromAmount(info.lastTopQualityCertView.forwardTransferScFee));
-            sc.pushKV("last mbtrScFee", ValueFromAmount(info.lastTopQualityCertView.mainchainBackwardTransferRequestScFee));
+            sc.pushKV("pastFtScFee", ValueFromAmount(info.pastEpochTopQualityCertView.forwardTransferScFee));
+            sc.pushKV("pastMbtrScFee", ValueFromAmount(info.pastEpochTopQualityCertView.mainchainBackwardTransferRequestScFee));
+            sc.pushKV("lastFtScFee", ValueFromAmount(info.lastTopQualityCertView.forwardTransferScFee));
+            sc.pushKV("lastMbtrScFee", ValueFromAmount(info.lastTopQualityCertView.mainchainBackwardTransferRequestScFee));
         }
  
         UniValue ia(UniValue::VARR);
@@ -1264,17 +1265,17 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
             o.pushKV("amount", ValueFromAmount(entry.second));
             ia.push_back(o);
         }
-        sc.pushKV("immature amounts", ia);
+        sc.pushKV("immatureAmounts", ia);
 
         UniValue sf(UniValue::VARR);
         for(const auto& entry: info.scFees)
         {
             UniValue o(UniValue::VOBJ);
             o.pushKV("forwardTxScFee", ValueFromAmount(entry.forwardTxScFee));
-            o.pushKV("   mbtrTxScFee", ValueFromAmount(entry.mbtrTxScFee));
+            o.pushKV("mbtrTxScFee", ValueFromAmount(entry.mbtrTxScFee));
             sf.push_back(o);
         }
-        sc.pushKV("sc fees", sf);
+        sc.pushKV("scFees", sf);
 
         // get unconfirmed data if any
         if (mempool.hasSidechainCertificate(scId))
@@ -1282,10 +1283,10 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
             const uint256& topQualCertHash    = mempool.mapSidechains.at(scId).GetTopQualityCert()->second;
             const CScCertificate& topQualCert = mempool.mapCertificate.at(topQualCertHash).GetCertificate();
  
-            sc.pushKV("unconf top quality certificate epoch",   topQualCert.epochNumber);
-            sc.pushKV("unconf top quality certificate hash",    topQualCertHash.GetHex());
-            sc.pushKV("unconf top quality certificate quality", topQualCert.quality);
-            sc.pushKV("unconf top quality certificate amount",  ValueFromAmount(topQualCert.GetValueOfBackwardTransfers()));
+            sc.pushKV("unconfTopQualityCertificateEpoch",   topQualCert.epochNumber);
+            sc.pushKV("unconfTopQualityCertificateHash",    topQualCertHash.GetHex());
+            sc.pushKV("unconfTopQualityCertificateQuality", topQualCert.quality);
+            sc.pushKV("unconfTopQualityCertificateAmount",  ValueFromAmount(topQualCert.GetValueOfBackwardTransfers()));
         }
 
         addScUnconfCcData(scId, sc);
@@ -1315,34 +1316,35 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
             }
 
             sc.pushKV("state", CSidechain::stateToString(CSidechain::State::UNCONFIRMED));
-            sc.pushKV("unconf creating tx hash", info.creationTxHash.GetHex());
-            sc.pushKV("unconf withdrawalEpochLength", info.fixedParams.withdrawalEpochLength);
+            sc.pushKV("unconfCreatingTxHash", info.creationTxHash.GetHex());
+            sc.pushKV("unconfWithdrawalEpochLength", info.fixedParams.withdrawalEpochLength);
+            sc.pushKV("unconfCertSubmissionWindowLength", info.GetCertSubmissionWindowLength());
 
             if (bVerbose)
             {
-                sc.pushKV("unconf certProvingSystem", Sidechain::ProvingSystemTypeToString(info.fixedParams.wCertVk.getProvingSystemType()));
-                sc.pushKV("unconf wCertVk", info.fixedParams.wCertVk.GetHexRepr());
-                sc.pushKV("unconf customData", HexStr(info.fixedParams.customData));
+                sc.pushKV("unconfCertProvingSystem", Sidechain::ProvingSystemTypeToString(info.fixedParams.wCertVk.getProvingSystemType()));
+                sc.pushKV("unconfWCertVk", info.fixedParams.wCertVk.GetHexRepr());
+                sc.pushKV("unconfCustomData", HexStr(info.fixedParams.customData));
 
                 if(info.fixedParams.constant.is_initialized())
-                    sc.pushKV("unconf constant", info.fixedParams.constant->GetHexRepr());
+                    sc.pushKV("unconfConstant", info.fixedParams.constant->GetHexRepr());
                 else
-                    sc.pushKV("unconf constant", std::string{"NOT INITIALIZED"});
+                    sc.pushKV("unconfConstant", std::string{"NOT INITIALIZED"});
 
                 if(info.fixedParams.wCeasedVk.is_initialized())
                 {
-                    sc.pushKV("unconf cswProvingSystem", Sidechain::ProvingSystemTypeToString(info.fixedParams.wCeasedVk.get().getProvingSystemType()));
-                    sc.pushKV("unconf wCeasedVk", info.fixedParams.wCeasedVk.get().GetHexRepr());
+                    sc.pushKV("unconfCswProvingSystem", Sidechain::ProvingSystemTypeToString(info.fixedParams.wCeasedVk.get().getProvingSystemType()));
+                    sc.pushKV("unconfWCeasedVk", info.fixedParams.wCeasedVk.get().GetHexRepr());
                 }
                 else
-                    sc.pushKV("unconf wCeasedVk", std::string{"NOT INITIALIZED"});
+                    sc.pushKV("unconfWCeasedVk", std::string{"NOT INITIALIZED"});
 
                 UniValue arrFieldElementConfig(UniValue::VARR);
                 for(const auto& cfgEntry: info.fixedParams.vFieldElementCertificateFieldConfig)
                 {
                     arrFieldElementConfig.push_back(cfgEntry.getBitSize());
                 }
-                sc.pushKV("unconf vFieldElementCertificateFieldConfig", arrFieldElementConfig);
+                sc.pushKV("unconfVFieldElementCertificateFieldConfig", arrFieldElementConfig);
 
                 UniValue arrBitVectorConfig(UniValue::VARR);
                 for(const auto& cfgEntry: info.fixedParams.vBitVectorCertificateFieldConfig)
@@ -1352,7 +1354,7 @@ bool FillScRecordFromInfo(const uint256& scId, const CSidechain& info, CSidechai
                     singlePair.push_back(cfgEntry.getMaxCompressedSizeBytes());
                     arrBitVectorConfig.push_back(singlePair);
                 }
-                sc.pushKV("unconf vBitVectorCertificateFieldConfig", arrBitVectorConfig);
+                sc.pushKV("unconfVBitVectorCertificateFieldConfig", arrBitVectorConfig);
             }
 
             addScUnconfCcData(scId, sc);
@@ -1502,38 +1504,39 @@ UniValue getscinfo(const UniValue& params, bool fHelp)
             "  \"to\":                    xx,      (numeric) index of the ending item (excluded in result)\n"
             "  \"items\":[\n"
             "   {\n"
-            "     \"scid\":                    xxxxx,   (string)  sidechain ID\n"
-            "     \"balance\":                 xxxxx,   (numeric) available balance\n"
-            "     \"epoch\":                   xxxxx,   (numeric) current epoch for this sidechain\n"
-            "     \"end epoch height\":        xxxxx,   (numeric) height of the last block of the current epoch\n"
-            "     \"state\":                   xxxxx,   (string)  state of the sidechain at the current chain height\n"
-            "     \"ceasing height\":          xxxxx,   (numeric) height at which the sidechain is considered ceased if a certificate has not been received\n"
-            "     \"creating tx hash\":        xxxxx,   (string)  txid of the creating transaction\n"
-            "     \"created at block height\": xxxxx,   (numeric) height of the above block\n"
-            "     \"last certificate epoch\":  xxxxx,   (numeric) last epoch number for which a certificate has been received\n"
-            "     \"last certificate hash\":   xxxxx,   (numeric) the hash of the last certificate that has been received\n"
-            "     \"last certificate quality\":xxxxx,   (numeric) the quality of the last certificate that has been received\n"
-            "     \"last certificate amount\": xxxxx,   (numeric) the amount of the last certificate that has been received\n"
-            "     \"active ftScFee\":          xxxxx,   (numeric) The currently active fee required to create a Forward Transfer to sidechain\n"
-            "     \"active mbtrScFee\":        xxxxx,   (numeric) The currently active fee required to create a Mainchain Backward Transfer Request to sidechain\n"
-            "     \"mbtrRequestDataLength\":   xxxxx,   (numeric) The size of the MBTR request data length\n"
-            "     \"withdrawalEpochLength\":   xxxxx,   (numeric) length of the withdrawal epoch\n"
-            "     \"certProvingSystem\"        xxxxx,   (numeric) The type of proving system used for certificate verification\n"
-            "     \"wCertVk\":                 xxxxx,   (string)  The verification key needed to verify a Withdrawal Certificate Proof, set at sc creation\n"
-            "     \"customData\":              xxxxx,   (string)  The arbitrary byte string of custom data set at sc creation\n"
-            "     \"constant\":                xxxxx,   (string)  The arbitrary byte string of constant set at sc creation\n"
-            "     \"cswProvingSystem\"         xxxxx,   (numeric) The type of proving system used for CSW verification\n"
-            "     \"wCeasedVk\":               xxxxx,   (string)  The verification key needed to verify a Ceased Sidechain Withdrawal input Proof, set at sc creation\n"
-            "     \"vFieldElementCertificateFieldConfig\"  xxxxx,   (string) A string representation of an array whose entries are sizes (in bits). Any certificate should have as many custom FieldElements with the corresponding size.\n"
-            "     \"vBitVectorCertificateFieldConfig\"    xxxxx,   (string) A string representation of an array whose entries are bitVectorSizeBits and maxCompressedSizeBytes pairs. Any certificate should have as many custom vBitVectorCertificateField with the corresponding sizes\n"
-            "     \"past ftScFee\":            xxxxx,   (numeric) The (past epoch) fee required to create a Forward Transfer to sidechain\n"
-            "     \"past mbtrScFee\":          xxxxx,   (numeric) The (past epoch) fee required to create a Mainchain Backward Transfer Request to sidechain\n"
-            "     \"last ftScFee\":            xxxxx,   (numeric) The (last epoch) fee required to create a Forward Transfer to sidechain\n"
-            "     \"last mbtrScFee\":          xxxxx,   (numeric) The (last epoch) fee required to create a Mainchain Backward Transfer Request to sidechain\n"
-            "     \"immature amounts\": [\n"
-            "       {\n"
-            "         \"maturityHeight\":      xxxxx,   (numeric) height at which fund will become part of spendable balance\n"
-            "         \"amount\":              xxxxx,   (numeric) immature fund\n"
+            "     \"scid\":                               xxxxx,   (string)  sidechain ID\n"
+            "     \"balance\":                            xxxxx,   (numeric) available balance\n"
+            "     \"epoch\":                              xxxxx,   (numeric) current epoch for this sidechain\n"
+            "     \"endEpochHeight\":                     xxxxx,   (numeric) height of the last block of the current epoch\n"
+            "     \"state\":                              xxxxx,   (string)  state of the sidechain at the current chain height\n"
+            "     \"ceasingHeight\":                      xxxxx,   (numeric) height at which the sidechain is considered ceased if a certificate has not been received\n"
+            "     \"creatingTxHash\":                     xxxxx,   (string)  txid of the creating transaction\n"
+            "     \"createdAtBlockHeight\":               xxxxx,   (numeric) height of the above block\n"
+            "     \"lastCertificateEpoch\":               xxxxx,   (numeric) last epoch number for which a certificate has been received\n"
+            "     \"lastCertificateHash\":                xxxxx,   (numeric) the hash of the last certificate that has been received\n"
+            "     \"lastCertificateQuality\":             xxxxx,   (numeric) the quality of the last certificate that has been received\n"
+            "     \"lastCertificateAmount\":              xxxxx,   (numeric) the amount of the last certificate that has been received\n"
+            "     \"activeFtScFee\":                      xxxxx,   (numeric) The currently active fee required to create a Forward Transfer to sidechain\n"
+            "     \"activeMbtrScFee\":                    xxxxx,   (numeric) The currently active fee required to create a Mainchain Backward Transfer Request to sidechain\n"
+            "     \"mbtrRequestDataLength\":              xxxxx,   (numeric) The size of the MBTR request data length\n"
+            "     \"withdrawalEpochLength\":              xxxxx,   (numeric) length of the withdrawal epoch\n"
+            "     \"certSubmissionWindowLength\":         xxxxx,   (numeric) length of the submission window for certificates\n"
+            "     \"certProvingSystem\"                   xxxxx,   (numeric) The type of proving system used for certificate verification\n"
+            "     \"wCertVk\":                            xxxxx,   (string)  The verification key needed to verify a Withdrawal Certificate Proof, set at sc creation\n"
+            "     \"customData\":                         xxxxx,   (string)  The arbitrary byte string of custom data set at sc creation\n"
+            "     \"constant\":                           xxxxx,   (string)  The arbitrary byte string of constant set at sc creation\n"
+            "     \"cswProvingSystem\"                    xxxxx,   (numeric) The type of proving system used for CSW verification\n"
+            "     \"wCeasedVk\":                          xxxxx,   (string)  The verification key needed to verify a Ceased Sidechain Withdrawal input Proof, set at sc creation\n"
+            "     \"vFieldElementCertificateFieldConfig\" xxxxx,   (string)  A string representation of an array whose entries are sizes (in bits). Any certificate should have as many custom FieldElements with the corresponding size.\n"
+            "     \"vBitVectorCertificateFieldConfig\"    xxxxx,   (string)  A string representation of an array whose entries are bitVectorSizeBits and maxCompressedSizeBytes pairs. Any certificate should have as many custom vBitVectorCertificateField with the corresponding sizes\n"
+            "     \"pastFtScFee\":                        xxxxx,   (numeric) The (past epoch) fee required to create a Forward Transfer to sidechain\n"
+            "     \"pastMbtrScFee\":                      xxxxx,   (numeric) The (past epoch) fee required to create a Mainchain Backward Transfer Request to sidechain\n"
+            "     \"lastFtScFee\":                        xxxxx,   (numeric) The (last epoch) fee required to create a Forward Transfer to sidechain\n"
+            "     \"lastMbtrScFee\":                      xxxxx,   (numeric) The (last epoch) fee required to create a Mainchain Backward Transfer Request to sidechain\n"
+            "     \"immatureAmounts\": [\n"              
+            "       {\n"                                  
+            "         \"maturityHeight\":                 xxxxx,   (numeric) height at which fund will become part of spendable balance\n"
+            "         \"amount\":                         xxxxx,   (numeric) immature fund\n"
             "       },\n"
             "       ... ]\n"
             "    },\n"


### PR DESCRIPTION
Added a K/V pair to getscinfo rpc cmd output that shows the number of blocks of the certificate submission window; also removed blanks from JSON Keys of getscinfo rpc cmd output and modified a lot of py tests accordingly.